### PR TITLE
Add customer, sales, and settings pages

### DIFF
--- a/src/app/app/customers/page.tsx
+++ b/src/app/app/customers/page.tsx
@@ -1,0 +1,55 @@
+import { revalidatePath } from "next/cache";
+
+interface Customer {
+  id: number;
+  name: string;
+  email: string;
+}
+
+let customers: Customer[] = [];
+
+async function listCustomers(): Promise<Customer[]> {
+  "use server";
+  return customers;
+}
+
+async function createCustomer(formData: FormData): Promise<void> {
+  "use server";
+  const name = formData.get("name")?.toString() || "";
+  const email = formData.get("email")?.toString() || "";
+  customers.push({ id: Date.now(), name, email });
+  revalidatePath("/app/customers");
+}
+
+export default async function CustomersPage() {
+  const allCustomers = await listCustomers();
+  return (
+    <div>
+      <h1 className="mb-4 text-xl font-bold">Customers</h1>
+      <form action={createCustomer} className="mb-4 flex flex-col gap-2">
+        <input
+          type="text"
+          name="name"
+          placeholder="Name"
+          className="border p-2"
+        />
+        <input
+          type="email"
+          name="email"
+          placeholder="Email"
+          className="border p-2"
+        />
+        <button type="submit" className="rounded bg-blue-500 p-2 text-white">
+          Add Customer
+        </button>
+      </form>
+      <ul>
+        {allCustomers.map((customer) => (
+          <li key={customer.id}>
+            {customer.name} ({customer.email})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/app/sales/page.tsx
+++ b/src/app/app/sales/page.tsx
@@ -1,0 +1,24 @@
+export default function SalesPage() {
+  return (
+    <div>
+      <h1 className="mb-4 text-xl font-bold">Create Invoice</h1>
+      <form action="/api/invoices" method="POST" className="flex flex-col gap-2">
+        <input
+          type="text"
+          name="customer"
+          placeholder="Customer"
+          className="border p-2"
+        />
+        <input
+          type="number"
+          name="amount"
+          placeholder="Amount"
+          className="border p-2"
+        />
+        <button type="submit" className="rounded bg-blue-500 p-2 text-white">
+          Create Invoice
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -1,0 +1,45 @@
+import { revalidatePath } from "next/cache";
+
+interface Organization {
+  id: number;
+  name: string;
+}
+
+let organizations: Organization[] = [];
+
+async function listOrganizations(): Promise<Organization[]> {
+  "use server";
+  return organizations;
+}
+
+async function createOrganization(formData: FormData): Promise<void> {
+  "use server";
+  const name = formData.get("name")?.toString() || "";
+  organizations.push({ id: Date.now(), name });
+  revalidatePath("/app/settings");
+}
+
+export default async function SettingsPage() {
+  const allOrgs = await listOrganizations();
+  return (
+    <div>
+      <h1 className="mb-4 text-xl font-bold">Organizations</h1>
+      <form action={createOrganization} className="mb-4 flex flex-col gap-2">
+        <input
+          type="text"
+          name="name"
+          placeholder="Name"
+          className="border p-2"
+        />
+        <button type="submit" className="rounded bg-blue-500 p-2 text-white">
+          Add Organization
+        </button>
+      </form>
+      <ul>
+        {allOrgs.map((org) => (
+          <li key={org.id}>{org.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add customers page with server actions to manage customer list
- add sales page with invoice form posting to `/api/invoices`
- add settings page with server actions for organizations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1087fa6f083298166f4e5334b8376