### PR TITLE
feat: track vendor bills and input VAT

### DIFF
--- a/prisma/migrations/20250829023353_m5_vendors_bills_input_vat/migration.sql
+++ b/prisma/migrations/20250829023353_m5_vendors_bills_input_vat/migration.sql
@@ -1,0 +1,259 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT,
+    "emailVerified" TIMESTAMP(3),
+    "image" TEXT,
+    "password" TEXT,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "refresh_token" TEXT,
+    "access_token" TEXT,
+    "expires_at" INTEGER,
+    "token_type" TEXT,
+    "scope" TEXT,
+    "id_token" TEXT,
+    "session_state" TEXT,
+
+    CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VerificationToken" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Org" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Org_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrgSettings" (
+    "orgId" TEXT NOT NULL,
+    "timezone" TEXT DEFAULT 'UTC',
+    "currency" TEXT DEFAULT 'USD',
+    "apiKey" TEXT,
+    "webhookUrl" TEXT,
+
+    CONSTRAINT "OrgSettings_pkey" PRIMARY KEY ("orgId")
+);
+
+-- CreateTable
+CREATE TABLE "UserOrg" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'member',
+
+    CONSTRAINT "UserOrg_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Customer" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT,
+
+    CONSTRAINT "Customer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TaxCode" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "rate" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "TaxCode_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Item" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "price" DECIMAL(10,2) NOT NULL,
+    "taxCodeId" TEXT,
+
+    CONSTRAINT "Item_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Invoice" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "customerId" TEXT,
+    "number" INTEGER NOT NULL DEFAULT 1,
+    "issueDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dueDate" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'draft',
+
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "InvoiceLine" (
+    "id" TEXT NOT NULL,
+    "invoiceId" TEXT NOT NULL,
+    "itemId" TEXT,
+    "description" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "unitPrice" DECIMAL(10,2) NOT NULL,
+    "taxCodeId" TEXT,
+
+    CONSTRAINT "InvoiceLine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Payment" (
+    "id" TEXT NOT NULL,
+    "invoiceId" TEXT NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "method" TEXT NOT NULL,
+    "receiptNumber" INTEGER NOT NULL,
+
+    CONSTRAINT "Payment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Vendor" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Vendor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Bill" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "vendorId" TEXT NOT NULL,
+    "billDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dueDate" TIMESTAMP(3),
+    "wht" DECIMAL(10,2),
+
+    CONSTRAINT "Bill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BillLine" (
+    "id" TEXT NOT NULL,
+    "billId" TEXT NOT NULL,
+    "description" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "unitCost" DECIMAL(10,2) NOT NULL,
+    "taxCodeId" TEXT,
+
+    CONSTRAINT "BillLine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken"("identifier", "token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrgSettings_apiKey_key" ON "OrgSettings"("apiKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserOrg_userId_orgId_key" ON "UserOrg"("userId", "orgId");
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrgSettings" ADD CONSTRAINT "OrgSettings_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserOrg" ADD CONSTRAINT "UserOrg_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserOrg" ADD CONSTRAINT "UserOrg_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Customer" ADD CONSTRAINT "Customer_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaxCode" ADD CONSTRAINT "TaxCode_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_taxCodeId_fkey" FOREIGN KEY ("taxCodeId") REFERENCES "TaxCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_taxCodeId_fkey" FOREIGN KEY ("taxCodeId") REFERENCES "TaxCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Vendor" ADD CONSTRAINT "Vendor_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bill" ADD CONSTRAINT "Bill_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bill" ADD CONSTRAINT "Bill_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "Vendor"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_billId_fkey" FOREIGN KEY ("billId") REFERENCES "Bill"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_taxCodeId_fkey" FOREIGN KEY ("taxCodeId") REFERENCES "TaxCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,8 @@ model Org {
   taxCodes   TaxCode[]
   items      Item[]
   invoices   Invoice[]
+  vendors    Vendor[]
+  bills      Bill[]
 }
 
 model OrgSettings {
@@ -105,6 +107,7 @@ model TaxCode {
   org    Org       @relation(fields: [orgId], references: [id])
   items  Item[]
   lines  InvoiceLine[]
+  billLines BillLine[]
 }
 
 model Item {
@@ -154,4 +157,35 @@ model Payment {
   method    String
   receiptNumber Int
   invoice   Invoice  @relation(fields: [invoiceId], references: [id])
+}
+
+model Vendor {
+  id     String @id @default(cuid())
+  orgId  String
+  name   String
+  org    Org    @relation(fields: [orgId], references: [id])
+  bills  Bill[]
+}
+
+model Bill {
+  id        String   @id @default(cuid())
+  orgId     String
+  vendorId  String
+  billDate  DateTime @default(now())
+  dueDate   DateTime?
+  wht       Decimal? @db.Decimal(10, 2)
+  org       Org      @relation(fields: [orgId], references: [id])
+  vendor    Vendor   @relation(fields: [vendorId], references: [id])
+  lines     BillLine[]
+}
+
+model BillLine {
+  id          String   @id @default(cuid())
+  billId      String
+  description String?
+  quantity    Int      @default(1)
+  unitCost    Decimal  @db.Decimal(10, 2)
+  taxCodeId   String?
+  bill        Bill     @relation(fields: [billId], references: [id])
+  taxCode     TaxCode? @relation(fields: [taxCodeId], references: [id])
 }

--- a/src/app/(app)/purchases/bills/page.tsx
+++ b/src/app/(app)/purchases/bills/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fmtMoney } from "@/lib/format";
+
+export default function BillsPage() {
+  const [vendors, setVendors] = useState<any[]>([]);
+  const [bills, setBills] = useState<any[]>([]);
+  const [form, setForm] = useState({
+    vendorId: "",
+    description: "",
+    amount: "",
+    taxCodeId: "",
+    whtRate: ""
+  });
+
+  async function load() {
+    const v = await fetch(`/api/vendors`).then((r) => r.json());
+    const b = await fetch(`/api/bills`).then((r) => r.json());
+    setVendors(v);
+    setBills(b);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch(`/api/bills`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        vendorId: form.vendorId,
+        lines: [
+          {
+            description: form.description,
+            quantity: 1,
+            unitCost: parseFloat(form.amount),
+            taxCodeId: form.taxCodeId || undefined
+          }
+        ],
+        whtRate: form.whtRate ? parseFloat(form.whtRate) : undefined
+      })
+    });
+    setForm({ vendorId: "", description: "", amount: "", taxCodeId: "", whtRate: "" });
+    await load();
+  }
+
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Bills</h1>
+      <form onSubmit={submit} className="space-y-2 mb-4">
+        <select
+          value={form.vendorId}
+          onChange={(e) => setForm({ ...form, vendorId: e.target.value })}
+          className="border p-1 w-full"
+          required
+        >
+          <option value="">Select vendor</option>
+          {vendors.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.name}
+            </option>
+          ))}
+        </select>
+        <input
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          placeholder="Description"
+          className="border p-1 w-full"
+          required
+        />
+        <input
+          type="number"
+          step="0.01"
+          value={form.amount}
+          onChange={(e) => setForm({ ...form, amount: e.target.value })}
+          placeholder="Amount"
+          className="border p-1 w-full"
+          required
+        />
+        <input
+          value={form.taxCodeId}
+          onChange={(e) => setForm({ ...form, taxCodeId: e.target.value })}
+          placeholder="Tax Code ID"
+          className="border p-1 w-full"
+        />
+        <input
+          type="number"
+          step="0.01"
+          value={form.whtRate}
+          onChange={(e) => setForm({ ...form, whtRate: e.target.value })}
+          placeholder="WHT Rate"
+          className="border p-1 w-full"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+          Add Bill
+        </button>
+      </form>
+      <table className="w-full text-left">
+        <thead>
+          <tr>
+            <th>Vendor</th>
+            <th>Total</th>
+            <th>Input VAT</th>
+          </tr>
+        </thead>
+        <tbody>
+          {bills.map((b) => (
+            <tr key={b.id} className="border-t">
+              <td>{b.vendor.name}</td>
+              <td>{fmtMoney(b.total)}</td>
+              <td>{fmtMoney(b.inputVat)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/(app)/reports/vat/page.tsx
+++ b/src/app/(app)/reports/vat/page.tsx
@@ -8,22 +8,20 @@ export default async function VatPage() {
   return (
     <div>
       <h1 className="text-xl mb-4">VAT Summary</h1>
-      <table className="text-left">
-        <thead>
-          <tr>
-            <th>Tax Code</th>
-            <th>VAT Collected</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.entries(data).map(([code, amount]) => (
-            <tr key={code} className="border-t">
-              <td>{code}</td>
-              <td>{fmtMoney(amount as number)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="grid grid-cols-3 gap-4 mb-8">
+        <div className="p-4 border rounded">
+          <div className="font-semibold">Output VAT</div>
+          <div>{fmtMoney(data.outputVat)}</div>
+        </div>
+        <div className="p-4 border rounded">
+          <div className="font-semibold">Input VAT</div>
+          <div>{fmtMoney(data.inputVat)}</div>
+        </div>
+        <div className="p-4 border rounded">
+          <div className="font-semibold">Net VAT</div>
+          <div>{fmtMoney(data.netVat)}</div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/vendors/page.tsx
+++ b/src/app/(app)/vendors/page.tsx
@@ -1,3 +1,34 @@
-export default function VendorsPage() {
-  return <div>Vendors placeholder</div>;
+import { revalidatePath } from "next/cache";
+
+async function createVendor(formData: FormData) {
+  "use server";
+  const name = formData.get("name") as string;
+  if (!name) return;
+  await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/vendors`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name })
+  });
+  revalidatePath("/vendors");
+}
+
+export default async function VendorsPage() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/vendors`, {
+    cache: "no-store"
+  });
+  const vendors = await res.json();
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Vendors</h1>
+      <form action={createVendor} className="flex space-x-2 mb-4">
+        <input name="name" placeholder="Name" className="border p-1" />
+        <button type="submit" className="bg-blue-500 text-white px-2">Add</button>
+      </form>
+      <ul className="list-disc pl-5">
+        {vendors.map((v: any) => (
+          <li key={v.id}>{v.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/src/app/api/bills/route.ts
+++ b/src/app/api/bills/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+interface BillLineInput {
+  description: string;
+  quantity: number;
+  unitCost: number;
+  taxCodeId?: string;
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) return new NextResponse("Unauthorized", { status: 401 });
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) return new NextResponse("No organization", { status: 400 });
+  const bills = await prisma.bill.findMany({
+    where: { orgId: userOrg.orgId },
+    include: { vendor: true, lines: { include: { taxCode: true } } }
+  });
+  const result = bills.map((b) => {
+    let base = 0;
+    let vat = 0;
+    for (const line of b.lines) {
+      const lineBase = Number(line.unitCost) * line.quantity;
+      base += lineBase;
+      if (line.taxCode) {
+        vat += lineBase * line.taxCode.rate;
+      }
+    }
+    return { ...b, total: base + vat, inputVat: vat };
+  });
+  return NextResponse.json(result);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) return new NextResponse("Unauthorized", { status: 401 });
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) return new NextResponse("No organization", { status: 400 });
+  const body = await req.json();
+  const { vendorId, lines, whtRate }: { vendorId: string; lines: BillLineInput[]; whtRate?: number } = body;
+  const formattedLines = lines.map((l) => ({
+    description: l.description,
+    quantity: l.quantity,
+    unitCost: new Prisma.Decimal(l.unitCost),
+    taxCodeId: l.taxCodeId
+  }));
+  const bill = await prisma.bill.create({
+    data: {
+      orgId: userOrg.orgId,
+      vendorId,
+      wht: whtRate ? new Prisma.Decimal(whtRate) : undefined,
+      lines: { create: formattedLines }
+    },
+    include: { vendor: true, lines: { include: { taxCode: true } } }
+  });
+  let base = 0;
+  let vat = 0;
+  for (const line of bill.lines) {
+    const lineBase = Number(line.unitCost) * line.quantity;
+    base += lineBase;
+    if (line.taxCode) {
+      vat += lineBase * line.taxCode.rate;
+    }
+  }
+  const wht = whtRate ? base * whtRate : 0;
+  return NextResponse.json({ ...bill, total: base + vat, inputVat: vat, wht });
+}

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+  const vendors = await prisma.vendor.findMany({
+    where: { orgId: userOrg.orgId }
+  });
+  return NextResponse.json(vendors);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+  const body = await req.json();
+  const { name } = body;
+  if (!name) {
+    return new NextResponse("Name required", { status: 400 });
+  }
+  const vendor = await prisma.vendor.create({
+    data: { orgId: userOrg.orgId, name }
+  });
+  return NextResponse.json(vendor);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ export function Sidebar() {
           <li><Link href="/sales/payments">Payments</Link></li>
           <li><Link href="/reports/ar-aging">Reports: A/R Aging</Link></li>
           <li><Link href="/reports/vat">Reports: VAT</Link></li>
+          <li><Link href="/app/purchases/bills">Purchases: Bills</Link></li>
           <li><Link href="/vendors">Vendors</Link></li>
           <li><Link href="/settings">Settings</Link></li>
         </ul>


### PR DESCRIPTION
## Summary
- add Vendor, Bill, and BillLine models with migration
- support vendor and bill APIs with input VAT and WHT calculations
- expand VAT report and UI pages for purchases, vendors, and summaries

## Testing
- `npx prisma migrate dev --name m5_vendors_bills_input_vat` *(fails: Can't reach database server at `localhost:5432`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1110305c88329aa58c2e379a8a4f2