### PR TITLE
feat: add bank transactions and reconciliation

### DIFF
--- a/prisma/migrations/20250829030000_m7_bank_transactions/migration.sql
+++ b/prisma/migrations/20250829030000_m7_bank_transactions/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "BankTransaction" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "bankName" TEXT NOT NULL,
+    "accountNo" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "amount" DECIMAL(10, 2) NOT NULL,
+    "type" TEXT NOT NULL,
+    "memo" TEXT,
+    "invoiceId" TEXT,
+    "paymentId" TEXT,
+    "billId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'UNMATCHED',
+    CONSTRAINT "BankTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BankTransaction_orgId_date_idx" ON "BankTransaction"("orgId", "date");
+
+-- AddForeignKey
+ALTER TABLE "BankTransaction" ADD CONSTRAINT "BankTransaction_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "BankTransaction" ADD CONSTRAINT "BankTransaction_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "BankTransaction" ADD CONSTRAINT "BankTransaction_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "Payment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "BankTransaction" ADD CONSTRAINT "BankTransaction_billId_fkey" FOREIGN KEY ("billId") REFERENCES "Bill"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,30 +8,29 @@ datasource db {
 }
 
 model User {
-  id            String   @id @default(cuid())
+  id            String    @id @default(cuid())
   name          String?
-  email         String?  @unique
+  email         String?   @unique
   emailVerified DateTime?
   image         String?
   password      String?
   accounts      Account[]
   sessions      Session[]
   orgs          UserOrg[]
-
 }
 
 model Account {
-  id                String @id @default(cuid())
+  id                String  @id @default(cuid())
   userId            String
   type              String
   provider          String
   providerAccountId String
-  refresh_token     String?  @db.Text
-  access_token      String?  @db.Text
+  refresh_token     String? @db.Text
+  access_token      String? @db.Text
   expires_at        Int?
   token_type        String?
   scope             String?
-  id_token          String?  @db.Text
+  id_token          String? @db.Text
   session_state     String?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -56,27 +55,28 @@ model VerificationToken {
 }
 
 model Org {
-  id         String       @id @default(cuid())
-  name       String
-  createdAt  DateTime     @default(now())
-  updatedAt  DateTime     @updatedAt
-  settings   OrgSettings?
-  users      UserOrg[]
-  customers  Customer[]
-  taxCodes   TaxCode[]
-  items      Item[]
-  invoices   Invoice[]
-  vendors    Vendor[]
-  bills      Bill[]
+  id               String            @id @default(cuid())
+  name             String
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  settings         OrgSettings?
+  users            UserOrg[]
+  customers        Customer[]
+  taxCodes         TaxCode[]
+  items            Item[]
+  invoices         Invoice[]
+  vendors          Vendor[]
+  bills            Bill[]
+  bankTransactions BankTransaction[]
 }
 
 model OrgSettings {
-  orgId     String  @id
-  timezone  String? @default("UTC")
-  currency  String? @default("USD")
-  apiKey    String? @unique
+  orgId      String  @id
+  timezone   String? @default("UTC")
+  currency   String? @default("USD")
+  apiKey     String? @unique
   webhookUrl String?
-  org       Org     @relation(fields: [orgId], references: [id])
+  org        Org     @relation(fields: [orgId], references: [id])
 }
 
 model UserOrg {
@@ -91,49 +91,50 @@ model UserOrg {
 }
 
 model Customer {
-  id      String   @id @default(cuid())
-  orgId   String
-  name    String
-  email   String?
-  org     Org      @relation(fields: [orgId], references: [id])
+  id       String    @id @default(cuid())
+  orgId    String
+  name     String
+  email    String?
+  org      Org       @relation(fields: [orgId], references: [id])
   invoices Invoice[]
 }
 
 model TaxCode {
-  id     String    @id @default(cuid())
-  orgId  String
-  name   String
-  rate   Float
-  org    Org       @relation(fields: [orgId], references: [id])
-  items  Item[]
-  lines  InvoiceLine[]
+  id        String        @id @default(cuid())
+  orgId     String
+  name      String
+  rate      Float
+  org       Org           @relation(fields: [orgId], references: [id])
+  items     Item[]
+  lines     InvoiceLine[]
   billLines BillLine[]
 }
 
 model Item {
-  id          String    @id @default(cuid())
+  id          String        @id @default(cuid())
   orgId       String
   name        String
   description String?
-  price       Decimal   @db.Decimal(10, 2)
-  org         Org       @relation(fields: [orgId], references: [id])
+  price       Decimal       @db.Decimal(10, 2)
+  org         Org           @relation(fields: [orgId], references: [id])
   taxCodeId   String?
-  taxCode     TaxCode?  @relation(fields: [taxCodeId], references: [id])
+  taxCode     TaxCode?      @relation(fields: [taxCodeId], references: [id])
   lines       InvoiceLine[]
 }
 
 model Invoice {
-  id         String        @id @default(cuid())
-  orgId      String
-  customerId String?
-  number     Int           @default(1)
-  issueDate  DateTime      @default(now())
-  dueDate    DateTime?
-  status     String        @default("draft")
-  org        Org           @relation(fields: [orgId], references: [id])
-  customer   Customer?     @relation(fields: [customerId], references: [id])
-  lines      InvoiceLine[]
-  payments   Payment[]
+  id               String            @id @default(cuid())
+  orgId            String
+  customerId       String?
+  number           Int               @default(1)
+  issueDate        DateTime          @default(now())
+  dueDate          DateTime?
+  status           String            @default("draft")
+  org              Org               @relation(fields: [orgId], references: [id])
+  customer         Customer?         @relation(fields: [customerId], references: [id])
+  lines            InvoiceLine[]
+  payments         Payment[]
+  bankTransactions BankTransaction[]
 }
 
 model InvoiceLine {
@@ -150,33 +151,35 @@ model InvoiceLine {
 }
 
 model Payment {
-  id        String   @id @default(cuid())
-  invoiceId String
-  amount    Decimal  @db.Decimal(10, 2)
-  date      DateTime @default(now())
-  method    String
-  receiptNumber Int
-  invoice   Invoice  @relation(fields: [invoiceId], references: [id])
+  id               String            @id @default(cuid())
+  invoiceId        String
+  amount           Decimal           @db.Decimal(10, 2)
+  date             DateTime          @default(now())
+  method           String
+  receiptNumber    Int
+  invoice          Invoice           @relation(fields: [invoiceId], references: [id])
+  bankTransactions BankTransaction[]
 }
 
 model Vendor {
-  id     String @id @default(cuid())
-  orgId  String
-  name   String
-  org    Org    @relation(fields: [orgId], references: [id])
-  bills  Bill[]
+  id    String @id @default(cuid())
+  orgId String
+  name  String
+  org   Org    @relation(fields: [orgId], references: [id])
+  bills Bill[]
 }
 
 model Bill {
-  id        String   @id @default(cuid())
-  orgId     String
-  vendorId  String
-  billDate  DateTime @default(now())
-  dueDate   DateTime?
-  wht       Decimal? @db.Decimal(10, 2)
-  org       Org      @relation(fields: [orgId], references: [id])
-  vendor    Vendor   @relation(fields: [vendorId], references: [id])
-  lines     BillLine[]
+  id               String            @id @default(cuid())
+  orgId            String
+  vendorId         String
+  billDate         DateTime          @default(now())
+  dueDate          DateTime?
+  wht              Decimal?          @db.Decimal(10, 2)
+  org              Org               @relation(fields: [orgId], references: [id])
+  vendor           Vendor            @relation(fields: [vendorId], references: [id])
+  lines            BillLine[]
+  bankTransactions BankTransaction[]
 }
 
 model BillLine {
@@ -188,4 +191,26 @@ model BillLine {
   taxCodeId   String?
   bill        Bill     @relation(fields: [billId], references: [id])
   taxCode     TaxCode? @relation(fields: [taxCodeId], references: [id])
+}
+
+model BankTransaction {
+  id        String   @id @default(cuid())
+  orgId     String
+  bankName  String
+  accountNo String
+  date      DateTime
+  amount    Decimal  @db.Decimal(10, 2)
+  type      String
+  memo      String?
+  invoiceId String?
+  paymentId String?
+  billId    String?
+  status    String   @default("UNMATCHED")
+
+  org     Org      @relation(fields: [orgId], references: [id])
+  invoice Invoice? @relation(fields: [invoiceId], references: [id])
+  payment Payment? @relation(fields: [paymentId], references: [id])
+  bill    Bill?    @relation(fields: [billId], references: [id])
+
+  @@index([orgId, date])
 }

--- a/src/app/(app)/bank/page.tsx
+++ b/src/app/(app)/bank/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function BankPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState("");
+  const [transactions, setTransactions] = useState<any[]>([]);
+
+  async function fetchTransactions() {
+    const res = await fetch("/api/bank/transactions");
+    if (res.ok) {
+      const data = await res.json();
+      setTransactions(data);
+    }
+  }
+
+  async function upload() {
+    if (!file) return;
+    const formData = new FormData();
+    formData.append("file", file);
+    const res = await fetch("/api/bank/import", {
+      method: "POST",
+      body: formData
+    });
+    if (res.ok) {
+      setStatus("Imported");
+      fetchTransactions();
+    } else {
+      setStatus("Import failed");
+    }
+  }
+
+  async function reconcile() {
+    setStatus("Reconciling...");
+    const res = await fetch("/api/bank/reconcile", { method: "POST" });
+    if (res.ok) {
+      const data = await res.json();
+      setStatus(`Matched ${data.matched}`);
+      fetchTransactions();
+    } else {
+      setStatus("Reconcile failed");
+    }
+  }
+
+  useEffect(() => {
+    fetchTransactions();
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Bank Reconciliation</h1>
+      <div className="space-x-2">
+        <input type="file" accept=".csv" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <button onClick={upload} className="px-2 py-1 border">Upload CSV</button>
+        <button onClick={reconcile} className="px-2 py-1 border">Reconcile</button>
+      </div>
+      {status && <p className="mt-2">{status}</p>}
+      <table className="mt-4 w-full">
+        <thead>
+          <tr>
+            <th className="text-left">Date</th>
+            <th className="text-left">Amount</th>
+            <th className="text-left">Memo</th>
+            <th className="text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {transactions.map((t) => (
+            <tr key={t.id} className="border-t">
+              <td>{new Date(t.date).toLocaleDateString()}</td>
+              <td>{t.amount}</td>
+              <td>{t.memo}</td>
+              <td>{t.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+
+  const form = await req.formData();
+  const file = form.get("file") as File | null;
+  const bankName = (form.get("bankName") as string) || "Bank";
+  const accountNo = (form.get("accountNo") as string) || "";
+
+  if (!file) {
+    return new NextResponse("No file", { status: 400 });
+  }
+
+  const text = await file.text();
+  const lines = text.trim().split(/\r?\n/).slice(1); // skip header
+  const data = lines
+    .map((line) => {
+      const [dateStr, amountStr, memo] = line.split(",");
+      if (!dateStr || !amountStr) return null;
+      const amount = parseFloat(amountStr);
+      if (isNaN(amount)) return null;
+      return {
+        orgId: userOrg.orgId,
+        bankName,
+        accountNo,
+        date: new Date(dateStr),
+        amount: new Prisma.Decimal(amount),
+        type: amount >= 0 ? "CREDIT" : "DEBIT",
+        memo
+      };
+    })
+    .filter(Boolean) as any[];
+
+  if (data.length === 0) {
+    return NextResponse.json({ inserted: 0 });
+  }
+
+  await prisma.bankTransaction.createMany({ data });
+  return NextResponse.json({ inserted: data.length });
+}

--- a/src/app/api/bank/reconcile/route.ts
+++ b/src/app/api/bank/reconcile/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+
+  const transactions = await prisma.bankTransaction.findMany({
+    where: { orgId: userOrg.orgId, status: "UNMATCHED" }
+  });
+
+  let matched = 0;
+  for (const t of transactions) {
+    const start = new Date(t.date);
+    start.setDate(start.getDate() - 3);
+    const end = new Date(t.date);
+    end.setDate(end.getDate() + 3);
+
+    const payment = await prisma.payment.findFirst({
+      where: {
+        amount: t.amount,
+        date: { gte: start, lte: end },
+        invoice: { orgId: userOrg.orgId }
+      }
+    });
+    if (payment) {
+      await prisma.bankTransaction.update({
+        where: { id: t.id },
+        data: { paymentId: payment.id, invoiceId: payment.invoiceId, status: "MATCHED" }
+      });
+      matched++;
+      continue;
+    }
+
+    const invoices = await prisma.invoice.findMany({
+      where: { orgId: userOrg.orgId, issueDate: { gte: start, lte: end } },
+      include: { lines: true }
+    });
+    const tAmount = parseFloat(t.amount.toString());
+    const invoice = invoices.find((inv) => {
+      const total = inv.lines.reduce((s, l) => s + parseFloat(l.unitPrice.toString()) * l.quantity, 0);
+      return Math.abs(total - tAmount) < 0.01;
+    });
+    if (invoice) {
+      await prisma.bankTransaction.update({
+        where: { id: t.id },
+        data: { invoiceId: invoice.id, status: "MATCHED" }
+      });
+      matched++;
+      continue;
+    }
+
+    const bills = await prisma.bill.findMany({
+      where: { orgId: userOrg.orgId, billDate: { gte: start, lte: end } },
+      include: { lines: true }
+    });
+    const bill = bills.find((b) => {
+      const total = b.lines.reduce((s, l) => s + parseFloat(l.unitCost.toString()) * l.quantity, 0);
+      return Math.abs(total - tAmount) < 0.01;
+    });
+    if (bill) {
+      await prisma.bankTransaction.update({
+        where: { id: t.id },
+        data: { billId: bill.id, status: "MATCHED" }
+      });
+      matched++;
+    }
+  }
+
+  return NextResponse.json({ matched });
+}

--- a/src/app/api/bank/transactions/route.ts
+++ b/src/app/api/bank/transactions/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+  const transactions = await prisma.bankTransaction.findMany({
+    where: { orgId: userOrg.orgId },
+    orderBy: { date: "desc" },
+    take: 50
+  });
+  return NextResponse.json(transactions);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,20 +1,29 @@
 import Link from "next/link";
 
+const links = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/customers", label: "Customers" },
+  { href: "/sales", label: "Sales (Create)" },
+  { href: "/sales/invoices", label: "Invoices" },
+  { href: "/sales/payments", label: "Payments" },
+  { href: "/reports/ar-aging", label: "Reports: A/R Aging" },
+  { href: "/reports/vat", label: "Reports: VAT" },
+  { href: "/app/purchases/bills", label: "Purchases: Bills" },
+  { href: "/vendors", label: "Vendors" },
+  { href: "/settings", label: "Settings" },
+  { href: "/app/bank", label: "Bank Reconciliation" }
+];
+
 export function Sidebar() {
   return (
     <aside className="w-64 bg-gray-100 p-4">
       <nav>
         <ul className="space-y-2">
-          <li><Link href="/dashboard">Dashboard</Link></li>
-          <li><Link href="/customers">Customers</Link></li>
-          <li><Link href="/sales">Sales (Create)</Link></li>
-          <li><Link href="/sales/invoices">Invoices</Link></li>
-          <li><Link href="/sales/payments">Payments</Link></li>
-          <li><Link href="/reports/ar-aging">Reports: A/R Aging</Link></li>
-          <li><Link href="/reports/vat">Reports: VAT</Link></li>
-          <li><Link href="/app/purchases/bills">Purchases: Bills</Link></li>
-          <li><Link href="/vendors">Vendors</Link></li>
-          <li><Link href="/settings">Settings</Link></li>
+          {links.map((link) => (
+            <li key={link.href}>
+              <Link href={link.href}>{link.label}</Link>
+            </li>
+          ))}
         </ul>
       </nav>
     </aside>


### PR DESCRIPTION
## Summary
- add `BankTransaction` Prisma model and migration
- implement bank import, reconciliation, and listing API routes
- add bank reconciliation UI and navigation link

## Testing
- `npx prisma migrate dev --name m7_bank_transactions` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1166c8aac8329b2722a769cd1ae95