### PR TITLE
feat: add estimates feature with VAT utilities

### DIFF
--- a/prisma/migrations/20250829030221_m8_estimates_quotes/migration.sql
+++ b/prisma/migrations/20250829030221_m8_estimates_quotes/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable
+CREATE TABLE "Estimate" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "customerId" TEXT,
+    "number" TEXT NOT NULL,
+    "issueDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiryDate" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "subTotal" DECIMAL(10,2) NOT NULL,
+    "vatTotal" DECIMAL(10,2) NOT NULL,
+    "total" DECIMAL(10,2) NOT NULL,
+
+    CONSTRAINT "Estimate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EstimateLine" (
+    "id" TEXT NOT NULL,
+    "estimateId" TEXT NOT NULL,
+    "description" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "unitPrice" DECIMAL(10,2) NOT NULL,
+    "taxCodeId" TEXT,
+
+    CONSTRAINT "EstimateLine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Estimate_number_key" ON "Estimate"("number");
+
+-- AddForeignKey
+ALTER TABLE "Estimate" ADD CONSTRAINT "Estimate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Estimate" ADD CONSTRAINT "Estimate_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EstimateLine" ADD CONSTRAINT "EstimateLine_estimateId_fkey" FOREIGN KEY ("estimateId") REFERENCES "Estimate"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EstimateLine" ADD CONSTRAINT "EstimateLine_taxCodeId_fkey" FOREIGN KEY ("taxCodeId") REFERENCES "TaxCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@ model Org {
   taxCodes         TaxCode[]
   items            Item[]
   invoices         Invoice[]
+  estimates        Estimate[]
   vendors          Vendor[]
   bills            Bill[]
   bankTransactions BankTransaction[]
@@ -97,6 +98,7 @@ model Customer {
   email    String?
   org      Org       @relation(fields: [orgId], references: [id])
   invoices Invoice[]
+  estimates Estimate[]
 }
 
 model TaxCode {
@@ -107,6 +109,7 @@ model TaxCode {
   org       Org           @relation(fields: [orgId], references: [id])
   items     Item[]
   lines     InvoiceLine[]
+  estimateLines EstimateLine[]
   billLines BillLine[]
 }
 
@@ -147,6 +150,33 @@ model InvoiceLine {
   taxCodeId   String?
   invoice     Invoice  @relation(fields: [invoiceId], references: [id])
   item        Item?    @relation(fields: [itemId], references: [id])
+  taxCode     TaxCode? @relation(fields: [taxCodeId], references: [id])
+}
+
+model Estimate {
+  id         String   @id @default(cuid())
+  orgId      String
+  customerId String?
+  number     String   @unique
+  issueDate  DateTime @default(now())
+  expiryDate DateTime?
+  status     String   @default("draft")
+  subTotal   Decimal  @db.Decimal(10, 2)
+  vatTotal   Decimal  @db.Decimal(10, 2)
+  total      Decimal  @db.Decimal(10, 2)
+  org        Org      @relation(fields: [orgId], references: [id])
+  customer   Customer? @relation(fields: [customerId], references: [id])
+  lines      EstimateLine[]
+}
+
+model EstimateLine {
+  id          String   @id @default(cuid())
+  estimateId  String
+  description String?
+  quantity    Int      @default(1)
+  unitPrice   Decimal  @db.Decimal(10, 2)
+  taxCodeId   String?
+  estimate    Estimate @relation(fields: [estimateId], references: [id])
   taxCode     TaxCode? @relation(fields: [taxCodeId], references: [id])
 }
 

--- a/src/app/(app)/sales/estimates/page.tsx
+++ b/src/app/(app)/sales/estimates/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fmtMoney, fmtDate } from "@/lib/format";
+
+interface LineForm {
+  description: string;
+  quantity: string;
+  unitPrice: string;
+  taxCodeId: string;
+}
+
+export default function EstimatesPage() {
+  const [customerId, setCustomerId] = useState("");
+  const [line, setLine] = useState<LineForm>({ description: "", quantity: "1", unitPrice: "", taxCodeId: "" });
+  const [lines, setLines] = useState<LineForm[]>([]);
+  const [estimates, setEstimates] = useState<any[]>([]);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    const e = await fetch("/api/estimates").then((r) => r.json());
+    setEstimates(e);
+  }
+
+  function addLine() {
+    if (!line.description || !line.unitPrice) return;
+    setLines([...lines, line]);
+    setLine({ description: "", quantity: "1", unitPrice: "", taxCodeId: "" });
+  }
+
+  async function saveEstimate() {
+    await fetch("/api/estimates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        customerId,
+        items: lines.map((l) => ({
+          description: l.description,
+          quantity: parseInt(l.quantity),
+          unitPrice: parseFloat(l.unitPrice),
+          taxCodeId: l.taxCodeId || undefined
+        }))
+      })
+    });
+    setCustomerId("");
+    setLines([]);
+    await load();
+  }
+
+  async function convert(id: string) {
+    await fetch(`/api/estimates/${id}/convert`, { method: "POST" });
+    await load();
+  }
+
+  return (
+    <div>
+      <h1 className="text-xl mb-4">Estimates</h1>
+      <div className="space-y-2 mb-6">
+        <input
+          value={customerId}
+          onChange={(e) => setCustomerId(e.target.value)}
+          placeholder="Customer ID"
+          className="border p-1 w-full"
+        />
+        <div className="flex gap-2">
+          <input
+            value={line.description}
+            onChange={(e) => setLine({ ...line, description: e.target.value })}
+            placeholder="Description"
+            className="border p-1 flex-1"
+          />
+          <input
+            type="number"
+            value={line.quantity}
+            onChange={(e) => setLine({ ...line, quantity: e.target.value })}
+            className="border p-1 w-20"
+          />
+          <input
+            type="number"
+            step="0.01"
+            value={line.unitPrice}
+            onChange={(e) => setLine({ ...line, unitPrice: e.target.value })}
+            className="border p-1 w-28"
+          />
+          <input
+            value={line.taxCodeId}
+            onChange={(e) => setLine({ ...line, taxCodeId: e.target.value })}
+            placeholder="Tax Code"
+            className="border p-1 w-28"
+          />
+          <button type="button" onClick={addLine} className="bg-gray-200 px-2">
+            Add
+          </button>
+        </div>
+        {lines.length > 0 && (
+          <ul className="list-disc pl-5">
+            {lines.map((l, i) => (
+              <li key={i}>{`${l.description} (${l.quantity} x ${l.unitPrice})`}</li>
+            ))}
+          </ul>
+        )}
+        <button onClick={saveEstimate} className="bg-blue-500 text-white px-2 py-1">
+          Save Estimate
+        </button>
+      </div>
+      <table className="w-full text-left">
+        <thead>
+          <tr>
+            <th>Number</th>
+            <th>Date</th>
+            <th>Total</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {estimates.map((est) => (
+            <tr key={est.id} className="border-t">
+              <td>{est.number}</td>
+              <td>{fmtDate(est.issueDate)}</td>
+              <td>{fmtMoney(est.total)}</td>
+              <td>{est.status}</td>
+              <td>
+                {est.status !== "converted" && (
+                  <button onClick={() => convert(est.id)} className="underline">
+                    Convert to Invoice
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/api/estimates/[id]/convert/route.ts
+++ b/src/app/api/estimates/[id]/convert/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+import { invoiceNumber } from "@/lib/numbering";
+import { calcLines } from "@/lib/vatCalc";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+
+  const estimate = await prisma.estimate.findFirst({
+    where: { id: params.id, orgId: userOrg.orgId },
+    include: { lines: true }
+  });
+  if (!estimate) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const number = await invoiceNumber();
+
+  const invoice = await prisma.invoice.create({
+    data: {
+      orgId: userOrg.orgId,
+      customerId: estimate.customerId,
+      number,
+      lines: {
+        create: estimate.lines.map((l) => ({
+          description: l.description,
+          quantity: l.quantity,
+          unitPrice: l.unitPrice,
+          taxCodeId: l.taxCodeId
+        }))
+      }
+    },
+    include: { lines: true, customer: true }
+  });
+
+  await prisma.estimate.update({
+    where: { id: estimate.id },
+    data: { status: "converted" }
+  });
+
+  const vatInputs = await Promise.all(
+    estimate.lines.map(async (l) => {
+      let rate = 0;
+      if (l.taxCodeId) {
+        const tc = await prisma.taxCode.findUnique({
+          where: { id: l.taxCodeId },
+          select: { rate: true }
+        });
+        rate = tc?.rate ?? 0;
+      }
+      return {
+        quantity: l.quantity,
+        unitPrice: parseFloat(l.unitPrice.toString()),
+        taxRate: rate
+      };
+    })
+  );
+  const totals = calcLines(vatInputs);
+
+  return NextResponse.json({ ...invoice, subTotal: totals.subTotal, vatTotal: totals.vatTotal, total: totals.total });
+}

--- a/src/app/api/estimates/route.ts
+++ b/src/app/api/estimates/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+import { calcLines, nextDocNumber } from "@/lib/vatCalc";
+import { Prisma } from "@prisma/client";
+
+interface EstimateItemInput {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxCodeId?: string;
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+  const estimates = await prisma.estimate.findMany({
+    where: { orgId: userOrg.orgId },
+    include: { customer: true }
+  });
+  return NextResponse.json(estimates);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+  const body = await req.json();
+  const { customerId, items }: { customerId: string; items: EstimateItemInput[] } = body;
+
+  const number = await nextDocNumber("EST", "estimate");
+
+  const vatInputs = await Promise.all(
+    items.map(async (item) => {
+      let rate = 0;
+      if (item.taxCodeId) {
+        const tc = await prisma.taxCode.findUnique({
+          where: { id: item.taxCodeId },
+          select: { rate: true }
+        });
+        rate = tc?.rate ?? 0;
+      }
+      return { quantity: item.quantity, unitPrice: item.unitPrice, taxRate: rate };
+    })
+  );
+
+  const totals = calcLines(vatInputs);
+
+  const lines = items.map((item) => ({
+    description: item.description,
+    quantity: item.quantity,
+    unitPrice: new Prisma.Decimal(item.unitPrice),
+    taxCodeId: item.taxCodeId
+  }));
+
+  const estimate = await prisma.estimate.create({
+    data: {
+      orgId: userOrg.orgId,
+      customerId,
+      number,
+      subTotal: new Prisma.Decimal(totals.subTotal),
+      vatTotal: new Prisma.Decimal(totals.vatTotal),
+      total: new Prisma.Decimal(totals.total),
+      lines: { create: lines }
+    },
+    include: { lines: true, customer: true }
+  });
+
+  return NextResponse.json(estimate);
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ const links = [
   { href: "/customers", label: "Customers" },
   { href: "/sales", label: "Sales (Create)" },
   { href: "/sales/invoices", label: "Invoices" },
+  { href: "/app/sales/estimates", label: "Sales: Estimates" },
   { href: "/sales/payments", label: "Payments" },
   { href: "/reports/ar-aging", label: "Reports: A/R Aging" },
   { href: "/reports/vat", label: "Reports: VAT" },

--- a/src/lib/vatCalc.ts
+++ b/src/lib/vatCalc.ts
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/prisma";
+
+export interface VatLineInput {
+  quantity: number;
+  unitPrice: number;
+  taxRate?: number;
+}
+
+export interface VatLineResult extends VatLineInput {
+  subTotal: number;
+  vat: number;
+  total: number;
+}
+
+export function calcLines(lines: VatLineInput[]) {
+  const detailed = lines.map((l) => {
+    const subTotal = l.quantity * l.unitPrice;
+    const vat = subTotal * (l.taxRate ?? 0);
+    const total = subTotal + vat;
+    return { ...l, subTotal, vat, total };
+  });
+  const subTotal = detailed.reduce((a, b) => a + b.subTotal, 0);
+  const vatTotal = detailed.reduce((a, b) => a + b.vat, 0);
+  const total = detailed.reduce((a, b) => a + b.total, 0);
+  return { lines: detailed, subTotal, vatTotal, total };
+}
+
+export async function nextDocNumber(prefix: string, model: "estimate" | "invoice" = "estimate") {
+  const year = new Date().getFullYear();
+  const base = `${prefix}-${year}`;
+  const last = await (prisma as any)[model].findFirst({
+    where: { number: { startsWith: base } },
+    orderBy: { number: "desc" },
+    select: { number: true }
+  });
+  const lastSeq = last?.number ? parseInt(String(last.number).split("-")[2] ?? "0") : 0;
+  const next = lastSeq + 1;
+  return `${base}-${next.toString().padStart(4, "0")}`;
+}


### PR DESCRIPTION
## Summary
- add Estimate and EstimateLine models
- implement VAT utilities for line calculations and doc numbering
- expose API and UI to manage and convert estimates
- link estimates in sidebar navigation

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Module not found)*
- `npx prisma migrate dev --name m8_estimates_quotes` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_68b117b5a80c8329a22c9a98f83cfaaa