### PR TITLE
Add inbound email ingestion and admin inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Sign-up/sign-in (email/password + optional Google)
 Protected /app/* with a clean, modern shell
 
 Brand assets in place (logo + favicon)
+
+## Inbound email
+- Create `InboundMailbox` entries mapping an email address to an org. Example: `bills@herobooks.net` -> some org ID.
+- Cron or manual trigger: `POST /api/admin/email-ingest/run` with header `x-ingest-secret: <EMAIL_INGEST_SECRET>` connects via IMAP and processes unseen messages.
+- Webhook: `POST /api/email/inbound` with the same `x-ingest-secret` and JSON payload `{from,to,subject,text,attachments:[{filename,contentType,contentBase64}]}`.
+- Both paths parse PDF attachments, create draft bills, and log results in `EmailIngestLog`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,3 +90,24 @@ model VerificationToken {
   expires    DateTime
   @@id([identifier, token])
 }
+
+model InboundMailbox {
+  id       String   @id @default(cuid())
+  email    String   @unique
+  orgId    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  logs     EmailIngestLog[]
+}
+
+model EmailIngestLog {
+  id        String   @id @default(cuid())
+  mailboxId String?
+  mailbox   InboundMailbox? @relation(fields: [mailboxId], references: [id])
+  vendor    String?
+  billId    String?
+  status    String
+  error     String?
+  createdAt DateTime @default(now())
+}
+

--- a/src/app/(app)/admin/inbox/page.tsx
+++ b/src/app/(app)/admin/inbox/page.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/lib/prisma";
+
+async function createMailbox(formData: FormData) {
+  'use server';
+  const email = formData.get('email') as string;
+  const orgId = formData.get('orgId') as string;
+  if (!email || !orgId) return;
+  await prisma.inboundMailbox.create({ data: { email: email.toLowerCase(), orgId } });
+  revalidatePath('/app/admin/inbox');
+}
+
+export default async function InboxPage() {
+  const logs = await prisma.emailIngestLog.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+  });
+  return (
+    <div className="p-6 text-slate-300">
+      <h1 className="mb-4 text-xl">Inbox</h1>
+      <form action={createMailbox} className="mb-6 flex gap-2">
+        <input
+          type="email"
+          name="email"
+          placeholder="Mailbox email"
+          className="rounded px-2 py-1 text-black"
+        />
+        <input
+          type="text"
+          name="orgId"
+          placeholder="Org ID"
+          className="rounded px-2 py-1 text-black"
+        />
+        <button type="submit" className="rounded bg-slate-700 px-3 py-1">
+          Add
+        </button>
+      </form>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="px-2 py-1">Vendor</th>
+            <th className="px-2 py-1">Status</th>
+            <th className="px-2 py-1">Bill</th>
+            <th className="px-2 py-1">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log) => (
+            <tr key={log.id} className="border-t border-slate-700">
+              <td className="px-2 py-1">{log.vendor || '-'}</td>
+              <td className="px-2 py-1">{log.status}</td>
+              <td className="px-2 py-1">
+                {log.billId ? (
+                  <Link href={`/app/purchases/bills/${log.billId}`}>View</Link>
+                ) : (
+                  '-' )}
+              </td>
+              <td className="px-2 py-1">
+                {log.createdAt?.toISOString?.() ?? ''}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/api/email/inbound/route.ts
+++ b/src/app/api/email/inbound/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
-import { runImapIngestion } from '@/lib/emailIngest';
+import { ingestParsedMessage } from '@/lib/emailIngest';
 
 export async function POST(req: Request) {
   const secret = req.headers.get('x-ingest-secret');
   if (!secret || secret !== process.env.EMAIL_INGEST_SECRET) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
-  await runImapIngestion();
+  const body = await req.json();
+  await ingestParsedMessage(body);
   return NextResponse.json({ status: 'ok' });
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ const links = [
   { href: "/app/sales", label: "Sales" },
   { href: "/app/vendors", label: "Vendors" },
   { href: "/app/settings", label: "Settings" },
+  { href: "/app/admin/inbox", label: "Admin: Inbox" },
 ];
 
 export default function Sidebar() {

--- a/src/lib/emailIngest.ts
+++ b/src/lib/emailIngest.ts
@@ -2,42 +2,96 @@ import { ImapFlow } from 'imapflow';
 import { simpleParser } from 'mailparser';
 import pdfParse from 'pdf-parse';
 import { prisma } from './prisma';
+import { runVendorExtractors } from './vendorExtractors';
 
-export async function emailIngest() {
+interface ParsedAttachment {
+  filename?: string;
+  contentType?: string;
+  contentBase64?: string;
+}
+
+interface ParsedMessage {
+  from?: string;
+  to?: string;
+  subject?: string;
+  text?: string;
+  attachments?: ParsedAttachment[];
+}
+
+export async function ingestParsedMessage(msg: ParsedMessage) {
+  const to = msg.to?.toLowerCase() || '';
+  const mailbox = await prisma.inboundMailbox.findUnique({ where: { email: to } });
+  if (!mailbox) {
+    await prisma.emailIngestLog.create({
+      data: { status: 'no-mailbox', error: `No mailbox for ${to}` },
+    });
+    return;
+  }
+  for (const att of msg.attachments || []) {
+    if (att.contentType === 'application/pdf' && att.contentBase64) {
+      try {
+        const pdf = await pdfParse(Buffer.from(att.contentBase64, 'base64'));
+        const vendorInfo = runVendorExtractors(pdf.text);
+        const vendorName = vendorInfo?.vendorName || 'Unknown Vendor';
+        const vendor = await prisma.vendor.upsert({
+          where: { orgId_name: { orgId: mailbox.orgId, name: vendorName } },
+          update: {},
+          create: { orgId: mailbox.orgId, name: vendorName },
+        });
+        const bill = await prisma.bill.create({
+          data: { orgId: mailbox.orgId, vendorId: vendor.id, status: 'draft' },
+        });
+        await prisma.emailIngestLog.create({
+          data: {
+            mailboxId: mailbox.id,
+            vendor: vendorName,
+            billId: bill.id,
+            status: 'ok',
+          },
+        });
+      } catch (err: any) {
+        await prisma.emailIngestLog.create({
+          data: {
+            mailboxId: mailbox.id,
+            status: 'error',
+            error: err.message,
+          },
+        });
+      }
+    }
+  }
+}
+
+export async function runImapIngestion() {
   const client = new ImapFlow({
     host: process.env.IMAP_HOST,
     port: Number(process.env.IMAP_PORT || 993),
     secure: process.env.IMAP_TLS !== 'false',
     auth: {
       user: process.env.IMAP_USER || '',
-      pass: process.env.IMAP_PASSWORD || ''
-    }
+      pass: process.env.IMAP_PASSWORD || '',
+    },
   });
-
   await client.connect();
   await client.selectMailbox('INBOX');
-
-  for await (const message of client.fetch('1:*', { source: true })) {
-    const parsed = await simpleParser(message.source as Buffer);
-    for (const attachment of parsed.attachments || []) {
-      if (attachment.contentType === 'application/pdf') {
-        const pdf = await pdfParse(attachment.content);
-        const vendorName = pdf.text.split('\n')[0]?.trim() || 'Unknown Vendor';
-        const vendor = await prisma.vendor.upsert({
-          where: { name: vendorName },
-          create: { name: vendorName, orgId: '' },
-          update: {}
-        });
-        await prisma.bill.create({
-          data: {
-            orgId: vendor.orgId,
-            vendorId: vendor.id,
-            status: 'draft'
-          }
-        });
-      }
-    }
+  const unseen = await client.search({ seen: false });
+  for (const seq of unseen) {
+    const { source } = await client.fetchOne(seq, { source: true });
+    const parsed = await simpleParser(source as Buffer);
+    const attachments = (parsed.attachments || []).map((a) => ({
+      filename: a.filename,
+      contentType: a.contentType,
+      contentBase64: (a.content as Buffer).toString('base64'),
+    }));
+    const to = parsed.to?.value?.[0]?.address || '';
+    await ingestParsedMessage({
+      from: parsed.from?.text,
+      to,
+      subject: parsed.subject,
+      text: parsed.text,
+      attachments,
+    });
+    await client.messageFlagsAdd(seq, ['\\Seen']);
   }
-
   await client.logout();
 }

--- a/src/lib/vendorExtractors.ts
+++ b/src/lib/vendorExtractors.ts
@@ -1,0 +1,36 @@
+interface ExtractResult {
+  vendorName: string;
+}
+
+type Extractor = (text: string) => ExtractResult | null;
+
+function autoParts(text: string): ExtractResult | null {
+  if (/autoparts/i.test(text)) {
+    return { vendorName: 'AutoParts' };
+  }
+  return null;
+}
+
+function regency(text: string): ExtractResult | null {
+  if (/regency/i.test(text)) {
+    return { vendorName: 'Regency' };
+  }
+  return null;
+}
+
+function beForward(text: string): ExtractResult | null {
+  if (/beforward/i.test(text)) {
+    return { vendorName: 'BeForward' };
+  }
+  return null;
+}
+
+const extractors: Extractor[] = [autoParts, regency, beForward];
+
+export function runVendorExtractors(text: string): ExtractResult | null {
+  for (const ex of extractors) {
+    const res = ex(text);
+    if (res) return res;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add InboundMailbox and EmailIngestLog Prisma models
- implement vendor extractors and IMAP ingestion with logging
- expose admin inbox UI and webhook for email ingestion

## Testing
- `npx prisma migrate dev --name m11_mailboxes_ingest_logs` *(fails: Environment variable not found: DATABASE_URL)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1275d7fb88329bf1de450ff6b3b6d