### PR TITLE
feat: restore bank reconciliation API

### DIFF
--- a/src/app/(app)/bank/page.tsx
+++ b/src/app/(app)/bank/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 export default function BankPage() {
   const [file, setFile] = useState<File | null>(null);
@@ -51,9 +53,9 @@ export default function BankPage() {
     <div>
       <h1 className="text-xl mb-4">Bank Reconciliation</h1>
       <div className="space-x-2">
-        <input type="file" accept=".csv" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-        <button onClick={upload} className="px-2 py-1 border">Upload CSV</button>
-        <button onClick={reconcile} className="px-2 py-1 border">Reconcile</button>
+        <Input type="file" accept=".csv" onChange={(e) => setFile(e.target.files?.[0] || null)} className="w-auto" />
+        <Button onClick={upload} variant="outline">Upload CSV</Button>
+        <Button onClick={reconcile} variant="outline">Reconcile</Button>
       </div>
       {status && <p className="mt-2">{status}</p>}
       <table className="mt-4 w-full">

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { addTransactions, BankTransaction } from '../../../../lib/bank';
+
+function parseCsv(text: string) {
+  const lines = text.trim().split(/\r?\n/);
+  lines.shift(); // remove header
+  return lines.filter(Boolean).map((line) => {
+    const [date, amount, memo] = line.split(',');
+    const txn: BankTransaction = {
+      id: Math.random().toString(36).slice(2),
+      date: new Date(date).toISOString(),
+      amount: Number(amount),
+      memo,
+      status: 'UNMATCHED',
+    };
+    return txn;
+  });
+}
+
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  const file = formData.get('file');
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: 'file required' }, { status: 400 });
+  }
+  const text = await file.text();
+  const txns = parseCsv(text);
+  addTransactions(txns);
+  return NextResponse.json({ imported: txns.length });
+}

--- a/src/app/api/bank/reconcile/route.ts
+++ b/src/app/api/bank/reconcile/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { reconcileTransactions } from '../../../../lib/bank';
+
+export async function POST() {
+  const matched = reconcileTransactions();
+  return NextResponse.json({ matched });
+}

--- a/src/app/api/bank/transactions/route.ts
+++ b/src/app/api/bank/transactions/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { getTransactions } from '../../../../lib/bank';
+
+export async function GET() {
+  return NextResponse.json(getTransactions());
+}

--- a/src/lib/bank.ts
+++ b/src/lib/bank.ts
@@ -1,0 +1,32 @@
+export type BankTransaction = {
+  id: string;
+  date: string; // ISO date string
+  amount: number;
+  memo?: string;
+  status: 'UNMATCHED' | 'MATCHED';
+};
+
+const bankTransactions: BankTransaction[] = [];
+
+export function getTransactions() {
+  return bankTransactions;
+}
+
+export function addTransactions(txns: BankTransaction[]) {
+  bankTransactions.push(...txns);
+}
+
+export function reconcileTransactions() {
+  let matched = 0;
+  for (const t of bankTransactions) {
+    if (t.status !== 'MATCHED') {
+      t.status = 'MATCHED';
+      matched++;
+    }
+  }
+  return matched;
+}
+
+export function resetTransactions() {
+  bankTransactions.length = 0;
+}


### PR DESCRIPTION
## Summary
- reintroduce bank reconciliation page with UI components
- add in-memory bank transaction store and API routes for import, reconciliation, and listing

## Testing
- `pnpm lint`
- `node -r sucrase/register test-bank.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b4704ec9348329b9870a7c7ee2a053