### PR TITLE
Restore estimate feature with API routes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Org {
   taxCodes  TaxCode[]
   items     Item[]
   invoices  Invoice[]
+  estimates Estimate[]
   createdAt DateTime     @default(now())
   updatedAt DateTime     @updatedAt
 }
@@ -124,6 +125,7 @@ model Customer {
   email   String?
   org     Org      @relation(fields: [orgId], references: [id])
   invoices Invoice[]
+  estimates Estimate[]
 }
 
 model TaxCode {
@@ -134,6 +136,7 @@ model TaxCode {
   org    Org       @relation(fields: [orgId], references: [id])
   items  Item[]
   lines  InvoiceLine[]
+  estimateLines EstimateLine[]
 }
 
 model Item {
@@ -173,6 +176,33 @@ model InvoiceLine {
   taxCodeId   String?
   invoice     Invoice  @relation(fields: [invoiceId], references: [id])
   item        Item?    @relation(fields: [itemId], references: [id])
+  taxCode     TaxCode? @relation(fields: [taxCodeId], references: [id])
+}
+
+model Estimate {
+  id         String   @id @default(cuid())
+  orgId      String
+  customerId String?
+  number     String   @unique
+  issueDate  DateTime @default(now())
+  expiryDate DateTime?
+  status     String   @default("draft")
+  subTotal   Decimal  @db.Decimal(10, 2)
+  vatTotal   Decimal  @db.Decimal(10, 2)
+  total      Decimal  @db.Decimal(10, 2)
+  org        Org      @relation(fields: [orgId], references: [id])
+  customer   Customer? @relation(fields: [customerId], references: [id])
+  lines      EstimateLine[]
+}
+
+model EstimateLine {
+  id          String   @id @default(cuid())
+  estimateId  String
+  description String?
+  quantity    Int      @default(1)
+  unitPrice   Decimal  @db.Decimal(10, 2)
+  taxCodeId   String?
+  estimate    Estimate @relation(fields: [estimateId], references: [id])
   taxCode     TaxCode? @relation(fields: [taxCodeId], references: [id])
 }
 

--- a/src/app/api/estimates/[id]/convert/route.ts
+++ b/src/app/api/estimates/[id]/convert/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+import { invoiceNumber } from "@/lib/numbering";
+import { calcLines } from "@/lib/vatCalc";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+
+  const estimate = await prisma.estimate.findFirst({
+    where: { id: params.id, orgId: userOrg.orgId },
+    include: { lines: true }
+  });
+  if (!estimate) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const number = await invoiceNumber();
+
+  const invoice = await prisma.invoice.create({
+    data: {
+      orgId: userOrg.orgId,
+      customerId: estimate.customerId,
+      number,
+      lines: {
+        create: estimate.lines.map((l) => ({
+          description: l.description,
+          quantity: l.quantity,
+          unitPrice: l.unitPrice,
+          taxCodeId: l.taxCodeId
+        }))
+      }
+    },
+    include: { lines: true, customer: true }
+  });
+
+  await prisma.estimate.update({
+    where: { id: estimate.id },
+    data: { status: "converted" }
+  });
+
+  const vatInputs = await Promise.all(
+    estimate.lines.map(async (l) => {
+      let rate = 0;
+      if (l.taxCodeId) {
+        const tc = await prisma.taxCode.findUnique({
+          where: { id: l.taxCodeId },
+          select: { rate: true }
+        });
+        rate = tc?.rate ?? 0;
+      }
+      return {
+        quantity: l.quantity,
+        unitPrice: parseFloat(l.unitPrice.toString()),
+        taxRate: rate
+      };
+    })
+  );
+  const totals = calcLines(vatInputs);
+
+  return NextResponse.json({ ...invoice, subTotal: totals.subTotal, vatTotal: totals.vatTotal, total: totals.total });
+}

--- a/src/app/api/estimates/route.ts
+++ b/src/app/api/estimates/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+import { calcLines, nextDocNumber } from "@/lib/vatCalc";
+import { Prisma } from "@prisma/client";
+
+interface EstimateItemInput {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxCodeId?: string;
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+  const estimates = await prisma.estimate.findMany({
+    where: { orgId: userOrg.orgId }
+  });
+  return NextResponse.json(estimates);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
+  const body = await req.json();
+  const { customerId, items }: { customerId: string; items: EstimateItemInput[] } = body;
+
+  const number = await nextDocNumber("EST", "estimate");
+
+  const vatInputs = await Promise.all(
+    items.map(async (item) => {
+      let rate = 0;
+      if (item.taxCodeId) {
+        const tc = await prisma.taxCode.findUnique({
+          where: { id: item.taxCodeId },
+          select: { rate: true }
+        });
+        rate = tc?.rate ?? 0;
+      }
+      return { quantity: item.quantity, unitPrice: item.unitPrice, taxRate: rate };
+    })
+  );
+
+  const totals = calcLines(vatInputs);
+
+  const lines = items.map((item) => ({
+    description: item.description,
+    quantity: item.quantity,
+    unitPrice: new Prisma.Decimal(item.unitPrice),
+    taxCodeId: item.taxCodeId
+  }));
+
+  const estimate = await prisma.estimate.create({
+    data: {
+      orgId: userOrg.orgId,
+      customerId,
+      number,
+      subTotal: new Prisma.Decimal(totals.subTotal),
+      vatTotal: new Prisma.Decimal(totals.vatTotal),
+      total: new Prisma.Decimal(totals.total),
+      lines: { create: lines }
+    },
+    include: { lines: true, customer: true }
+  });
+
+  return NextResponse.json(estimate);
+}

--- a/src/lib/vatCalc.ts
+++ b/src/lib/vatCalc.ts
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/prisma";
+
+export interface VatLineInput {
+  quantity: number;
+  unitPrice: number;
+  taxRate?: number;
+}
+
+export interface VatLineResult extends VatLineInput {
+  subTotal: number;
+  vat: number;
+  total: number;
+}
+
+export function calcLines(lines: VatLineInput[]) {
+  const detailed = lines.map((l) => {
+    const subTotal = l.quantity * l.unitPrice;
+    const vat = subTotal * (l.taxRate ?? 0);
+    const total = subTotal + vat;
+    return { ...l, subTotal, vat, total };
+  });
+  const subTotal = detailed.reduce((a, b) => a + b.subTotal, 0);
+  const vatTotal = detailed.reduce((a, b) => a + b.vat, 0);
+  const total = detailed.reduce((a, b) => a + b.total, 0);
+  return { lines: detailed, subTotal, vatTotal, total };
+}
+
+export async function nextDocNumber(prefix: string, model: "estimate" | "invoice" = "estimate") {
+  const year = new Date().getFullYear();
+  const base = `${prefix}-${year}`;
+  const last = await (prisma as any)[model].findFirst({
+    where: { number: { startsWith: base } },
+    orderBy: { number: "desc" },
+    select: { number: true }
+  });
+  const lastSeq = last?.number ? parseInt(String(last.number).split("-")[2] ?? "0") : 0;
+  const next = lastSeq + 1;
+  return `${base}-${next.toString().padStart(4, "0")}`;
+}


### PR DESCRIPTION
## Summary
- reintroduce estimate data models and VAT calculation utilities
- add `/api/estimates` endpoint for listing and creating estimates
- add `/api/estimates/[id]/convert` to turn estimates into invoices

## Testing
- `pnpm prisma:generate`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b471844e608329822cd370564dc0be