### PR TITLE
feat: restore accounting models with tenant isolation

### DIFF
--- a/prisma/migrations/20250829023353_m5_vendors_bills_input_vat/migration.sql
+++ b/prisma/migrations/20250829023353_m5_vendors_bills_input_vat/migration.sql
@@ -1,157 +1,9 @@
 -- CreateTable
-CREATE TABLE "User" (
-    "id" TEXT NOT NULL,
-    "name" TEXT,
-    "email" TEXT,
-    "emailVerified" TIMESTAMP(3),
-    "image" TEXT,
-    "password" TEXT,
-
-    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Account" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "type" TEXT NOT NULL,
-    "provider" TEXT NOT NULL,
-    "providerAccountId" TEXT NOT NULL,
-    "refresh_token" TEXT,
-    "access_token" TEXT,
-    "expires_at" INTEGER,
-    "token_type" TEXT,
-    "scope" TEXT,
-    "id_token" TEXT,
-    "session_state" TEXT,
-
-    CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Session" (
-    "id" TEXT NOT NULL,
-    "sessionToken" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "expires" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "VerificationToken" (
-    "identifier" TEXT NOT NULL,
-    "token" TEXT NOT NULL,
-    "expires" TIMESTAMP(3) NOT NULL
-);
-
--- CreateTable
-CREATE TABLE "Org" (
-    "id" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "Org_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "OrgSettings" (
-    "orgId" TEXT NOT NULL,
-    "timezone" TEXT DEFAULT 'UTC',
-    "currency" TEXT DEFAULT 'USD',
-    "apiKey" TEXT,
-    "webhookUrl" TEXT,
-
-    CONSTRAINT "OrgSettings_pkey" PRIMARY KEY ("orgId")
-);
-
--- CreateTable
-CREATE TABLE "UserOrg" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "role" TEXT NOT NULL DEFAULT 'member',
-
-    CONSTRAINT "UserOrg_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Customer" (
-    "id" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "email" TEXT,
-
-    CONSTRAINT "Customer_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "TaxCode" (
-    "id" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "rate" DOUBLE PRECISION NOT NULL,
-
-    CONSTRAINT "TaxCode_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Item" (
-    "id" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "description" TEXT,
-    "price" DECIMAL(10,2) NOT NULL,
-    "taxCodeId" TEXT,
-
-    CONSTRAINT "Item_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Invoice" (
-    "id" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "customerId" TEXT,
-    "number" INTEGER NOT NULL DEFAULT 1,
-    "issueDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "dueDate" TIMESTAMP(3),
-    "status" TEXT NOT NULL DEFAULT 'draft',
-
-    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "InvoiceLine" (
-    "id" TEXT NOT NULL,
-    "invoiceId" TEXT NOT NULL,
-    "itemId" TEXT,
-    "description" TEXT,
-    "quantity" INTEGER NOT NULL DEFAULT 1,
-    "unitPrice" DECIMAL(10,2) NOT NULL,
-    "taxCodeId" TEXT,
-
-    CONSTRAINT "InvoiceLine_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Payment" (
-    "id" TEXT NOT NULL,
-    "invoiceId" TEXT NOT NULL,
-    "amount" DECIMAL(10,2) NOT NULL,
-    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "method" TEXT NOT NULL,
-    "receiptNumber" INTEGER NOT NULL,
-
-    CONSTRAINT "Payment_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
 CREATE TABLE "Vendor" (
     "id" TEXT NOT NULL,
     "orgId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
-
+    "email" TEXT,
     CONSTRAINT "Vendor_pkey" PRIMARY KEY ("id")
 );
 
@@ -163,7 +15,6 @@ CREATE TABLE "Bill" (
     "billDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "dueDate" TIMESTAMP(3),
     "wht" DECIMAL(10,2),
-
     CONSTRAINT "Bill_pkey" PRIMARY KEY ("id")
 );
 
@@ -171,89 +22,22 @@ CREATE TABLE "Bill" (
 CREATE TABLE "BillLine" (
     "id" TEXT NOT NULL,
     "billId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
     "description" TEXT,
     "quantity" INTEGER NOT NULL DEFAULT 1,
     "unitCost" DECIMAL(10,2) NOT NULL,
     "taxCodeId" TEXT,
-
     CONSTRAINT "BillLine_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
-
--- CreateIndex
-CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
-
--- CreateIndex
-CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
-
--- CreateIndex
-CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken"("identifier", "token");
-
--- CreateIndex
-CREATE UNIQUE INDEX "OrgSettings_apiKey_key" ON "OrgSettings"("apiKey");
-
--- CreateIndex
-CREATE UNIQUE INDEX "UserOrg_userId_orgId_key" ON "UserOrg"("userId", "orgId");
-
--- AddForeignKey
-ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "OrgSettings" ADD CONSTRAINT "OrgSettings_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "UserOrg" ADD CONSTRAINT "UserOrg_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "UserOrg" ADD CONSTRAINT "UserOrg_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Customer" ADD CONSTRAINT "Customer_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "TaxCode" ADD CONSTRAINT "TaxCode_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Item" ADD CONSTRAINT "Item_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Item" ADD CONSTRAINT "Item_taxCodeId_fkey" FOREIGN KEY ("taxCodeId") REFERENCES "TaxCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_taxCodeId_fkey" FOREIGN KEY ("taxCodeId") REFERENCES "TaxCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Payment" ADD CONSTRAINT "Payment_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+CREATE UNIQUE INDEX "Vendor_id_orgId_key" ON "Vendor"("id", "orgId");
+CREATE UNIQUE INDEX "Bill_id_orgId_key" ON "Bill"("id", "orgId");
+CREATE UNIQUE INDEX "BillLine_id_orgId_key" ON "BillLine"("id", "orgId");
 
 -- AddForeignKey
 ALTER TABLE "Vendor" ADD CONSTRAINT "Vendor_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "Bill" ADD CONSTRAINT "Bill_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "Bill" ADD CONSTRAINT "Bill_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "Vendor"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_billId_fkey" FOREIGN KEY ("billId") REFERENCES "Bill"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_taxCodeId_fkey" FOREIGN KEY ("taxCodeId") REFERENCES "TaxCode"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-

--- a/prisma/migrations/20250831174029_composite_fks/migration.sql
+++ b/prisma/migrations/20250831174029_composite_fks/migration.sql
@@ -1,0 +1,239 @@
+/*
+  Warnings:
+
+  - The primary key for the `OrgSettings` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `currency` on the `OrgSettings` table. All the data in the column will be lost.
+  - You are about to drop the column `timezone` on the `OrgSettings` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[id,orgId]` on the table `BankTransaction` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `Customer` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `Estimate` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[orgId,number]` on the table `Estimate` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `EstimateLine` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `Invoice` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[orgId,number]` on the table `Invoice` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `InvoiceLine` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `Item` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[orgId]` on the table `OrgSettings` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `Payment` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,orgId]` on the table `TaxCode` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[token]` on the table `VerificationToken` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `orgId` to the `EstimateLine` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `orgId` to the `InvoiceLine` table without a default value. This is not possible if the table is not empty.
+  - The required column `id` was added to the `OrgSettings` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+  - Added the required column `orgId` to the `Payment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `User` table without a default value. This is not possible if the table is not empty.
+  - Changed the type of `role` on the `UserOrg` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('OWNER', 'ADMIN', 'ACCOUNTANT', 'AGENT', 'VIEWER');
+
+-- DropForeignKey
+ALTER TABLE "Account" DROP CONSTRAINT "Account_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BankTransaction" DROP CONSTRAINT "BankTransaction_billId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BankTransaction" DROP CONSTRAINT "BankTransaction_invoiceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BankTransaction" DROP CONSTRAINT "BankTransaction_paymentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Bill" DROP CONSTRAINT "Bill_vendorId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BillLine" DROP CONSTRAINT "BillLine_billId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BillLine" DROP CONSTRAINT "BillLine_taxCodeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Estimate" DROP CONSTRAINT "Estimate_customerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "EstimateLine" DROP CONSTRAINT "EstimateLine_estimateId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "EstimateLine" DROP CONSTRAINT "EstimateLine_taxCodeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Invoice" DROP CONSTRAINT "Invoice_customerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "InvoiceLine" DROP CONSTRAINT "InvoiceLine_invoiceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "InvoiceLine" DROP CONSTRAINT "InvoiceLine_itemId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "InvoiceLine" DROP CONSTRAINT "InvoiceLine_taxCodeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Item" DROP CONSTRAINT "Item_taxCodeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Payment" DROP CONSTRAINT "Payment_invoiceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_userId_fkey";
+
+-- DropIndex
+DROP INDEX "Estimate_number_key";
+
+-- DropIndex
+DROP INDEX "VerificationToken_identifier_token_key";
+
+-- AlterTable
+ALTER TABLE "EstimateLine" ADD COLUMN     "orgId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "InvoiceLine" ADD COLUMN     "orgId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Org" ADD COLUMN     "country" TEXT NOT NULL DEFAULT 'GY';
+
+-- AlterTable
+ALTER TABLE "OrgSettings" DROP CONSTRAINT "OrgSettings_pkey",
+DROP COLUMN "currency",
+DROP COLUMN "timezone",
+ADD COLUMN     "allowNegativeStock" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "brandHex" TEXT,
+ADD COLUMN     "id" TEXT NOT NULL,
+ADD CONSTRAINT "OrgSettings_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "Payment" ADD COLUMN     "orgId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "passwordHash" TEXT,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "UserOrg" DROP COLUMN "role",
+ADD COLUMN     "role" "Role" NOT NULL;
+
+-- AlterTable
+ALTER TABLE "VerificationToken" ADD CONSTRAINT "VerificationToken_pkey" PRIMARY KEY ("identifier", "token");
+
+-- CreateTable
+CREATE TABLE "InboundMailbox" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InboundMailbox_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EmailIngestLog" (
+    "id" TEXT NOT NULL,
+    "mailboxId" TEXT,
+    "vendor" TEXT,
+    "billId" TEXT,
+    "status" TEXT NOT NULL,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EmailIngestLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InboundMailbox_email_key" ON "InboundMailbox"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BankTransaction_id_orgId_key" ON "BankTransaction"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Customer_id_orgId_key" ON "Customer"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Estimate_id_orgId_key" ON "Estimate"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Estimate_orgId_number_key" ON "Estimate"("orgId", "number");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EstimateLine_id_orgId_key" ON "EstimateLine"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invoice_id_orgId_key" ON "Invoice"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invoice_orgId_number_key" ON "Invoice"("orgId", "number");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InvoiceLine_id_orgId_key" ON "InvoiceLine"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Item_id_orgId_key" ON "Item"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrgSettings_orgId_key" ON "OrgSettings"("orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Payment_id_orgId_key" ON "Payment"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TaxCode_id_orgId_key" ON "TaxCode"("id", "orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_token_key" ON "VerificationToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EmailIngestLog" ADD CONSTRAINT "EmailIngestLog_mailboxId_fkey" FOREIGN KEY ("mailboxId") REFERENCES "InboundMailbox"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Item" ADD CONSTRAINT "Item_taxCodeId_orgId_fkey" FOREIGN KEY ("taxCodeId", "orgId") REFERENCES "TaxCode"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_customerId_orgId_fkey" FOREIGN KEY ("customerId", "orgId") REFERENCES "Customer"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_invoiceId_orgId_fkey" FOREIGN KEY ("invoiceId", "orgId") REFERENCES "Invoice"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_itemId_orgId_fkey" FOREIGN KEY ("itemId", "orgId") REFERENCES "Item"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceLine" ADD CONSTRAINT "InvoiceLine_taxCodeId_orgId_fkey" FOREIGN KEY ("taxCodeId", "orgId") REFERENCES "TaxCode"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_invoiceId_orgId_fkey" FOREIGN KEY ("invoiceId", "orgId") REFERENCES "Invoice"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bill" ADD CONSTRAINT "Bill_vendorId_orgId_fkey" FOREIGN KEY ("vendorId", "orgId") REFERENCES "Vendor"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_billId_orgId_fkey" FOREIGN KEY ("billId", "orgId") REFERENCES "Bill"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_taxCodeId_orgId_fkey" FOREIGN KEY ("taxCodeId", "orgId") REFERENCES "TaxCode"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Estimate" ADD CONSTRAINT "Estimate_customerId_orgId_fkey" FOREIGN KEY ("customerId", "orgId") REFERENCES "Customer"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EstimateLine" ADD CONSTRAINT "EstimateLine_estimateId_orgId_fkey" FOREIGN KEY ("estimateId", "orgId") REFERENCES "Estimate"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EstimateLine" ADD CONSTRAINT "EstimateLine_taxCodeId_orgId_fkey" FOREIGN KEY ("taxCodeId", "orgId") REFERENCES "TaxCode"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BankTransaction" ADD CONSTRAINT "BankTransaction_invoiceId_orgId_fkey" FOREIGN KEY ("invoiceId", "orgId") REFERENCES "Invoice"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BankTransaction" ADD CONSTRAINT "BankTransaction_paymentId_orgId_fkey" FOREIGN KEY ("paymentId", "orgId") REFERENCES "Payment"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BankTransaction" ADD CONSTRAINT "BankTransaction_billId_orgId_fkey" FOREIGN KEY ("billId", "orgId") REFERENCES "Bill"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,44 +16,53 @@ enum Role {
 }
 
 model User {
-  id             String   @id @default(cuid())
-  name           String?
-  email          String?  @unique
-  emailVerified  DateTime?
-  image          String?
-  passwordHash   String?
-  accounts       Account[]
-  sessions       Session[]
-  memberships    UserOrg[]
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id            String    @id @default(cuid())
+  name          String?
+  email         String?   @unique
+  emailVerified DateTime?
+  image         String?
+  passwordHash  String?
+  accounts      Account[]
+  sessions      Session[]
+  memberships   UserOrg[]
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
 }
 
 model Org {
-  id         String    @id @default(cuid())
-  name       String
-  country    String    @default("GY")
-  settings   OrgSettings?
-  members    UserOrg[]
-  createdAt  DateTime  @default(now())
-  updatedAt  DateTime  @updatedAt
+  id               String            @id @default(cuid())
+  name             String
+  country          String            @default("GY")
+  settings         OrgSettings?
+  members          UserOrg[]
+  customers        Customer[]
+  taxCodes         TaxCode[]
+  items            Item[]
+  invoices         Invoice[]
+  vendors          Vendor[]
+  bills            Bill[]
+  estimates        Estimate[]
+  bankTransactions BankTransaction[]
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
 }
 
 model OrgSettings {
-  id                  String  @id @default(cuid())
-  orgId               String  @unique
-  org                 Org     @relation(fields: [orgId], references: [id])
-  brandHex            String? // primary color for theming
-  allowNegativeStock  Boolean @default(false)
+  id                 String  @id @default(cuid())
+  orgId              String  @unique
+  org                Org     @relation(fields: [orgId], references: [id])
+  brandHex           String? // primary color for theming
+  allowNegativeStock Boolean @default(false)
 }
 
 model UserOrg {
-  id        String  @id @default(cuid())
-  userId    String
-  orgId     String
-  role      Role
-  user      User    @relation(fields: [userId], references: [id])
-  org       Org     @relation(fields: [orgId], references: [id])
+  id     String @id @default(cuid())
+  userId String
+  orgId  String
+  role   Role
+  user   User   @relation(fields: [userId], references: [id])
+  org    Org    @relation(fields: [orgId], references: [id])
+
   @@unique([userId, orgId])
 }
 
@@ -88,26 +97,207 @@ model VerificationToken {
   identifier String
   token      String   @unique
   expires    DateTime
+
   @@id([identifier, token])
 }
 
 model InboundMailbox {
-  id       String   @id @default(cuid())
-  email    String   @unique
-  orgId    String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  logs     EmailIngestLog[]
+  id        String           @id @default(cuid())
+  email     String           @unique
+  orgId     String
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+  logs      EmailIngestLog[]
 }
 
 model EmailIngestLog {
-  id        String   @id @default(cuid())
+  id        String          @id @default(cuid())
   mailboxId String?
   mailbox   InboundMailbox? @relation(fields: [mailboxId], references: [id])
   vendor    String?
   billId    String?
   status    String
   error     String?
-  createdAt DateTime @default(now())
+  createdAt DateTime        @default(now())
 }
 
+model Customer {
+  id        String     @id @default(cuid())
+  orgId     String
+  name      String
+  email     String?
+  org       Org        @relation(fields: [orgId], references: [id])
+  invoices  Invoice[]
+  estimates Estimate[]
+
+  @@unique([id, orgId])
+}
+
+model TaxCode {
+  id            String         @id @default(cuid())
+  orgId         String
+  name          String
+  rate          Float
+  org           Org            @relation(fields: [orgId], references: [id])
+  items         Item[]
+  invoiceLines  InvoiceLine[]
+  billLines     BillLine[]
+  estimateLines EstimateLine[]
+
+  @@unique([id, orgId])
+}
+
+model Item {
+  id           String        @id @default(cuid())
+  orgId        String
+  name         String
+  description  String?
+  price        Decimal       @db.Decimal(10, 2)
+  taxCodeId    String?
+  org          Org           @relation(fields: [orgId], references: [id])
+  taxCode      TaxCode?      @relation(fields: [taxCodeId, orgId], references: [id, orgId])
+  invoiceLines InvoiceLine[]
+
+  @@unique([id, orgId])
+}
+
+model Invoice {
+  id               String            @id @default(cuid())
+  orgId            String
+  customerId       String?
+  number           Int               @default(1)
+  issueDate        DateTime          @default(now())
+  dueDate          DateTime?
+  status           String            @default("draft")
+  org              Org               @relation(fields: [orgId], references: [id])
+  customer         Customer?         @relation(fields: [customerId, orgId], references: [id, orgId])
+  lines            InvoiceLine[]
+  payments         Payment[]
+  bankTransactions BankTransaction[]
+
+  @@unique([id, orgId])
+  @@unique([orgId, number])
+}
+
+model InvoiceLine {
+  id          String   @id @default(cuid())
+  invoiceId   String
+  orgId       String
+  itemId      String?
+  description String?
+  quantity    Int      @default(1)
+  unitPrice   Decimal  @db.Decimal(10, 2)
+  taxCodeId   String?
+  invoice     Invoice  @relation(fields: [invoiceId, orgId], references: [id, orgId])
+  item        Item?    @relation(fields: [itemId, orgId], references: [id, orgId])
+  taxCode     TaxCode? @relation(fields: [taxCodeId, orgId], references: [id, orgId])
+
+  @@unique([id, orgId])
+}
+
+model Payment {
+  id               String            @id @default(cuid())
+  invoiceId        String
+  orgId            String
+  amount           Decimal           @db.Decimal(10, 2)
+  date             DateTime          @default(now())
+  invoice          Invoice           @relation(fields: [invoiceId, orgId], references: [id, orgId])
+  bankTransactions BankTransaction[]
+
+  @@unique([id, orgId])
+}
+
+model Vendor {
+  id    String  @id @default(cuid())
+  orgId String
+  name  String
+  email String?
+  org   Org     @relation(fields: [orgId], references: [id])
+  bills Bill[]
+
+  @@unique([id, orgId])
+}
+
+model Bill {
+  id               String            @id @default(cuid())
+  orgId            String
+  vendorId         String
+  billDate         DateTime          @default(now())
+  dueDate          DateTime?
+  wht              Decimal?          @db.Decimal(10, 2)
+  org              Org               @relation(fields: [orgId], references: [id])
+  vendor           Vendor            @relation(fields: [vendorId, orgId], references: [id, orgId])
+  lines            BillLine[]
+  bankTransactions BankTransaction[]
+
+  @@unique([id, orgId])
+}
+
+model BillLine {
+  id          String   @id @default(cuid())
+  billId      String
+  orgId       String
+  description String?
+  quantity    Int      @default(1)
+  unitCost    Decimal  @db.Decimal(10, 2)
+  taxCodeId   String?
+  bill        Bill     @relation(fields: [billId, orgId], references: [id, orgId])
+  taxCode     TaxCode? @relation(fields: [taxCodeId, orgId], references: [id, orgId])
+
+  @@unique([id, orgId])
+}
+
+model Estimate {
+  id         String         @id @default(cuid())
+  orgId      String
+  customerId String?
+  number     String
+  issueDate  DateTime       @default(now())
+  expiryDate DateTime?
+  status     String         @default("draft")
+  subTotal   Decimal        @db.Decimal(10, 2)
+  vatTotal   Decimal        @db.Decimal(10, 2)
+  total      Decimal        @db.Decimal(10, 2)
+  org        Org            @relation(fields: [orgId], references: [id])
+  customer   Customer?      @relation(fields: [customerId, orgId], references: [id, orgId])
+  lines      EstimateLine[]
+
+  @@unique([id, orgId])
+  @@unique([orgId, number])
+}
+
+model EstimateLine {
+  id          String   @id @default(cuid())
+  estimateId  String
+  orgId       String
+  description String?
+  quantity    Int      @default(1)
+  unitPrice   Decimal  @db.Decimal(10, 2)
+  taxCodeId   String?
+  estimate    Estimate @relation(fields: [estimateId, orgId], references: [id, orgId])
+  taxCode     TaxCode? @relation(fields: [taxCodeId, orgId], references: [id, orgId])
+
+  @@unique([id, orgId])
+}
+
+model BankTransaction {
+  id        String   @id @default(cuid())
+  orgId     String
+  bankName  String
+  accountNo String
+  date      DateTime
+  amount    Decimal  @db.Decimal(10, 2)
+  type      String
+  memo      String?
+  invoiceId String?
+  paymentId String?
+  billId    String?
+  status    String   @default("UNMATCHED")
+  org       Org      @relation(fields: [orgId], references: [id])
+  invoice   Invoice? @relation(fields: [invoiceId, orgId], references: [id, orgId])
+  payment   Payment? @relation(fields: [paymentId, orgId], references: [id, orgId])
+  bill      Bill?    @relation(fields: [billId, orgId], references: [id, orgId])
+
+  @@unique([id, orgId])
+  @@index([orgId, date])
+}


### PR DESCRIPTION
## Summary
- reintroduce customer/invoice/bill/estimate/bankTransaction models
- add composite foreign keys for org-level isolation
- simplify vendor/bill migration to only add new tables

## Testing
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/herobooks npx prisma migrate dev --name composite-fks`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68b487bde3d4832985310273d6d0974b