### PR TITLE
Use robust CSV parsing and allow negative transaction reconciliation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "mailparser": "^3.6.4",
         "next": "14.2.5",
         "next-auth": "^4.24.7",
+        "papaparse": "^5.5.3",
         "pdf-parse": "^1.1.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -2175,6 +2176,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parseley": {
       "version": "0.12.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mailparser": "^3.6.4",
     "next": "14.2.5",
     "next-auth": "^4.24.7",
+    "papaparse": "^5.5.3",
     "pdf-parse": "^1.1.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
+import Papa from "papaparse";
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
@@ -28,10 +29,12 @@ export async function POST(req: Request) {
   }
 
   const text = await file.text();
-  const lines = text.trim().split(/\r?\n/).slice(1); // skip header
-  const data = lines
-    .map((line) => {
-      const [dateStr, amountStr, memo] = line.split(",");
+  const parsed = Papa.parse<string[]>(text, { skipEmptyLines: true });
+  const rows = parsed.data as string[][];
+  const data = rows
+    .slice(1) // skip header
+    .map((cols) => {
+      const [dateStr, amountStr, memo] = cols;
       if (!dateStr || !amountStr) return null;
       const amount = parseFloat(amountStr);
       if (isNaN(amount)) return null;

--- a/src/app/api/bank/reconcile/route.ts
+++ b/src/app/api/bank/reconcile/route.ts
@@ -49,7 +49,10 @@ export async function POST() {
     });
     const tAmount = parseFloat(t.amount.toString());
     const invoice = invoices.find((inv) => {
-      const total = inv.lines.reduce((s, l) => s + parseFloat(l.unitPrice.toString()) * l.quantity, 0);
+      const total = inv.lines.reduce(
+        (s, l) => s + parseFloat(l.unitPrice.toString()) * l.quantity,
+        0
+      );
       return Math.abs(total - tAmount) < 0.01;
     });
     if (invoice) {
@@ -66,8 +69,11 @@ export async function POST() {
       include: { lines: true }
     });
     const bill = bills.find((b) => {
-      const total = b.lines.reduce((s, l) => s + parseFloat(l.unitCost.toString()) * l.quantity, 0);
-      return Math.abs(total - tAmount) < 0.01;
+      const total = b.lines.reduce(
+        (s, l) => s + parseFloat(l.unitCost.toString()) * l.quantity,
+        0
+      );
+      return Math.abs(total - Math.abs(tAmount)) < 0.01;
     });
     if (bill) {
       await prisma.bankTransaction.update({


### PR DESCRIPTION
## Summary
- use `papaparse` to reliably parse uploaded bank CSVs, supporting quoted values
- match bill totals against the absolute value of transaction amounts so debits reconcile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b491ce3dbc8329b773b4865fd1bdcf