### PR TITLE
fix: enforce unique item updates and clean bank import amounts

### DIFF
--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
     .map((cols) => {
       const [dateStr, amountStr, memo] = cols;
       if (!dateStr || !amountStr) return null;
-      const amount = parseFloat(amountStr);
+      const amount = parseFloat(amountStr.replace(/,/g, ""));
       if (isNaN(amount)) return null;
       return {
         orgId: userOrg.orgId,

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -76,7 +76,7 @@ export async function POST(req: Request) {
             throw new Error("INSUFFICIENT_STOCK");
           }
           await tx.item.update({
-            where: { id: dbItem.id, orgId: userOrg.orgId },
+            where: { id: dbItem.id },
             data: { qtyOnHand: dbItem.qtyOnHand - item.quantity }
           });
           let taxCodeId = item.taxCodeId ?? dbItem.taxCodeId ?? undefined;


### PR DESCRIPTION
## Summary
- ensure invoice item updates use a unique ID filter
- strip commas from imported bank transaction amounts before parsing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b49c2b4a48832999a2aec686356c31