### PR TITLE
Guard payment and receipt APIs by organization

### DIFF
--- a/src/app/api/email/send-receipt/route.ts
+++ b/src/app/api/email/send-receipt/route.ts
@@ -13,9 +13,16 @@ export async function POST(req: Request) {
   if (!session) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userOrg = await prisma.userOrg.findFirst({
+    where: { userId: session.user.id },
+    select: { orgId: true }
+  });
+  if (!userOrg) {
+    return new NextResponse("No organization", { status: 400 });
+  }
   const { paymentId } = await req.json();
-  const payment = await prisma.payment.findUnique({
-    where: { id: paymentId },
+  const payment = await prisma.payment.findFirst({
+    where: { id: paymentId, invoice: { orgId: userOrg.orgId } },
     include: { invoice: { include: { customer: true } } }
   });
   if (!payment || !payment.invoice?.customer?.email) {


### PR DESCRIPTION
## Summary
- Load the caller's organization when creating payments and ensure invoices belong to it
- Verify payments belong to the user's org before emailing receipts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7c949a883298f36b23b7d59b3f4