### PR TITLE
feat: use org model in bootstrap API route

### DIFF
--- a/src/app/api/admin/bootstrap-org/route.ts
+++ b/src/app/api/admin/bootstrap-org/route.ts
@@ -10,14 +10,14 @@ export async function POST() {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const existing = await prisma.organization.findFirst({
+  const existing = await prisma.org.findFirst({
     where: { ownerId: session.user.id }
   });
   if (existing) {
     return NextResponse.json(existing);
   }
 
-  const org = await prisma.organization.create({
+  const org = await prisma.org.create({
     data: {
       name: "Demo Org",
       ownerId: session.user.id,


### PR DESCRIPTION
## Summary
- use `prisma.org` in bootstrap org route

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c0f9faa083298b609ddfae4e6227