### PR TITLE
Use membership model for org ownership

### DIFF
--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -5,12 +5,12 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session || !session.user) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
-
+  const userId = (session.user as { id: string }).id;
   const customers = await prisma.customer.findMany({
-    where: { organization: { ownerId: session.user.id } }
+    where: { org: { members: { some: { userId } } } }
   });
 
   return NextResponse.json(customers);


### PR DESCRIPTION
## Summary
- look up existing organization membership instead of org.ownerId in bootstrap route
- create owner membership when bootstrapping a new org
- query customers by org membership

## Testing
- `pnpm lint`
- `pnpm build` *(fails: src/app/api/admin/rotate-api-key/route.ts:13:22 - 'session.user' is possibly 'undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68b50d4dcba083299ad27b3af170b4ac