### PR TITLE
refactor migrations for incremental vendor and org updates

### DIFF
--- a/prisma/migrations/20250829023353_m5_vendors_bills_input_vat/migration.sql
+++ b/prisma/migrations/20250829023353_m5_vendors_bills_input_vat/migration.sql
@@ -1,43 +1,37 @@
--- CreateTable
-CREATE TABLE "Vendor" (
-    "id" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "name" TEXT NOT NULL,
-    "email" TEXT,
-    CONSTRAINT "Vendor_pkey" PRIMARY KEY ("id")
-);
+-- Adjust existing vendor/bill tables instead of recreating them
+-- Ensure UUID generation extension is available
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
--- CreateTable
-CREATE TABLE "Bill" (
-    "id" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "vendorId" TEXT NOT NULL,
-    "billDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "dueDate" TIMESTAMP(3),
-    "wht" DECIMAL(10,2),
-    CONSTRAINT "Bill_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "BillLine" (
-    "id" TEXT NOT NULL,
-    "billId" TEXT NOT NULL,
-    "orgId" TEXT NOT NULL,
-    "description" TEXT,
-    "quantity" INTEGER NOT NULL DEFAULT 1,
-    "unitCost" DECIMAL(10,2) NOT NULL,
-    "taxCodeId" TEXT,
-    CONSTRAINT "BillLine_pkey" PRIMARY KEY ("id")
-);
-
--- CreateIndex
-CREATE UNIQUE INDEX "Vendor_id_orgId_key" ON "Vendor"("id", "orgId");
-CREATE UNIQUE INDEX "Bill_id_orgId_key" ON "Bill"("id", "orgId");
-CREATE UNIQUE INDEX "BillLine_id_orgId_key" ON "BillLine"("id", "orgId");
-
--- AddForeignKey
+-- Vendor table updates
+ALTER TABLE "Vendor"
+  ADD COLUMN IF NOT EXISTS "orgId" TEXT,
+  ADD COLUMN IF NOT EXISTS "email" TEXT;
+ALTER TABLE "Vendor"
+  ALTER COLUMN "orgId" SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "Vendor_id_orgId_key" ON "Vendor"("id", "orgId");
 ALTER TABLE "Vendor" ADD CONSTRAINT "Vendor_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Bill table updates
+ALTER TABLE "Bill"
+  ADD COLUMN IF NOT EXISTS "orgId" TEXT,
+  ADD COLUMN IF NOT EXISTS "vendorId" TEXT,
+  ADD COLUMN IF NOT EXISTS "billDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS "dueDate" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "wht" DECIMAL(10,2);
+ALTER TABLE "Bill"
+  ALTER COLUMN "orgId" SET NOT NULL,
+  ALTER COLUMN "vendorId" SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "Bill_id_orgId_key" ON "Bill"("id", "orgId");
 ALTER TABLE "Bill" ADD CONSTRAINT "Bill_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "Bill" ADD CONSTRAINT "Bill_vendorId_orgId_fkey" FOREIGN KEY ("vendorId", "orgId") REFERENCES "Vendor"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- BillLine table updates
+ALTER TABLE "BillLine"
+  ADD COLUMN IF NOT EXISTS "orgId" TEXT,
+  ADD COLUMN IF NOT EXISTS "taxCodeId" TEXT;
+ALTER TABLE "BillLine"
+  ALTER COLUMN "orgId" SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "BillLine_id_orgId_key" ON "BillLine"("id", "orgId");
 ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_billId_orgId_fkey" FOREIGN KEY ("billId", "orgId") REFERENCES "Bill"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_taxCodeId_orgId_fkey" FOREIGN KEY ("taxCodeId", "orgId") REFERENCES "TaxCode"("id", "orgId") ON DELETE SET NULL ON UPDATE CASCADE;
+


### PR DESCRIPTION
## Summary
- Backfill and enforce new `OrgSettings.id` primary key, migrate `User.updatedAt`, and map `UserOrg.role` strings to enum values
- Convert vendor/bill creation migration to incremental `ALTER TABLE` updates

## Testing
- `npx prisma generate`
- `npx prisma migrate dev --name test` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68b511fa14248329bf5485f0636d602f