### PR TITLE
chore: add migration for composite bill foreign keys

### DIFF
--- a/prisma/migrations/20250831180000_drop_legacy_bill_fks/migration.sql
+++ b/prisma/migrations/20250831180000_drop_legacy_bill_fks/migration.sql
@@ -1,0 +1,14 @@
+-- Drop legacy single-column foreign keys
+ALTER TABLE "Bill" DROP CONSTRAINT IF EXISTS "Bill_vendorId_fkey";
+ALTER TABLE "BillLine" DROP CONSTRAINT IF EXISTS "BillLine_billId_fkey";
+ALTER TABLE "BillLine" DROP CONSTRAINT IF EXISTS "BillLine_taxCodeId_fkey";
+
+-- Add composite foreign keys
+ALTER TABLE "Bill" ADD CONSTRAINT "Bill_vendorId_orgId_fkey" FOREIGN KEY ("vendorId", "orgId") REFERENCES "Vendor"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_billId_orgId_fkey" FOREIGN KEY ("billId", "orgId") REFERENCES "Bill"("id", "orgId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "BillLine" ADD CONSTRAINT "BillLine_taxCodeId_orgId_fkey" FOREIGN KEY ("taxCodeId", "orgId") REFERENCES "TaxCode"("id", "orgId") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Indexes for the new composite keys
+CREATE INDEX IF NOT EXISTS "Bill_vendorId_orgId_idx" ON "Bill"("vendorId", "orgId");
+CREATE INDEX IF NOT EXISTS "BillLine_billId_orgId_idx" ON "BillLine"("billId", "orgId");
+CREATE INDEX IF NOT EXISTS "BillLine_taxCodeId_orgId_idx" ON "BillLine"("taxCodeId", "orgId");


### PR DESCRIPTION
## Summary
- drop legacy bill and billline foreign keys
- add composite org-scoped foreign keys and supporting indexes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/herobooks" npx prisma migrate dev --skip-generate` *(fails: The underlying table for model `Vendor` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a322d6488329b844fbda8f72ef1a