### PR TITLE
Add user id guard for API key rotation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,7 @@ model OrgSettings {
   org                Org     @relation(fields: [orgId], references: [id])
   brandHex           String? // primary color for theming
   allowNegativeStock Boolean @default(false)
+  apiKey             String? @unique
 }
 
 model UserOrg {

--- a/src/app/api/admin/rotate-api-key/route.ts
+++ b/src/app/api/admin/rotate-api-key/route.ts
@@ -6,11 +6,12 @@ import { randomBytes } from "crypto";
 
 export async function POST() {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  const userId = (session?.user as { id?: string })?.id;
+  if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {


### PR DESCRIPTION
## Summary
- ensure rotate API key route checks for authenticated user
- include `apiKey` field on OrgSettings schema

## Testing
- `pnpm build` *(fails: Property 'vatCode' does not exist on type 'PrismaClient<...>')*

------
https://chatgpt.com/codex/tasks/task_e_68b5adff6e6483298822d81676d7672d