### PR TITLE
fix: update tax code references

### DIFF
--- a/src/app/api/admin/seed-tax/route.ts
+++ b/src/app/api/admin/seed-tax/route.ts
@@ -2,18 +2,22 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { DEFAULT_VAT_CODES } from "@/lib/defaultVatCodes";
 
-// Upsert default VAT codes
+// Upsert default tax codes for all organizations
 export async function POST() {
-  for (const code of DEFAULT_VAT_CODES) {
-    await prisma.vatCode.upsert({
-      where: { organizationId_code: { organizationId: null, code: code.code } },
-      update: { name: code.name, rate: code.rate },
-      create: {
-        code: code.code,
-        name: code.name,
-        rate: code.rate
-      }
-    });
+  const orgs = await prisma.org.findMany({ select: { id: true } });
+  for (const { id: orgId } of orgs) {
+    for (const code of DEFAULT_VAT_CODES) {
+      await prisma.taxCode.upsert({
+        where: { id: `${orgId}-${code.code}` },
+        update: { name: code.name, rate: code.rate },
+        create: {
+          id: `${orgId}-${code.code}`,
+          orgId,
+          name: code.name,
+          rate: code.rate
+        }
+      });
+    }
   }
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/set-webhook/route.ts
+++ b/src/app/api/admin/set-webhook/route.ts
@@ -5,12 +5,13 @@ import { prisma } from "@/lib/prisma";
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session || !session.user) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
   const { url } = await req.json();
+  const userId = (session.user as { id: string }).id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {


### PR DESCRIPTION
## Summary
- replace deprecated `prisma.vatCode` usage with `prisma.taxCode`
- guard admin webhook route against missing session user

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b5b0f9500083299c9787c920a9bd30