### PR TITLE
Scope invoice creation by organization

### DIFF
--- a/src/app/api/v1/invoices/route.ts
+++ b/src/app/api/v1/invoices/route.ts
@@ -11,34 +11,102 @@ export async function POST(req: Request) {
   const org = await orgFromApiKey(apiKey);
   if (!org) return new NextResponse("Unauthorized", { status: 401 });
   const body = await req.json();
-  const { customerId, items } = body;
+  const { customerId, items = [] } = body;
 
-  const customer = await prisma.customer.findFirst({
-    where: { id: customerId, orgId: org.id },
-    select: { id: true }
+  const orgRecord = await prisma.org.findUnique({
+    where: { id: org.id },
+    include: { settings: true }
   });
-  if (!customer) {
-    return new NextResponse("Invalid customer", { status: 400 });
-  }
+  const allowNegativeStock = orgRecord?.settings?.allowNegativeStock ?? false;
+
   const number = await invoiceNumber();
-  const lines: any[] = [];
-  for (const item of items || []) {
-    lines.push({
-      description: item.description,
-      quantity: item.quantity,
-      unitPrice: new Prisma.Decimal(item.unitPrice),
-      taxCodeId: item.taxCodeId
+
+  try {
+    const invoice = await prisma.$transaction(async (tx) => {
+      const customer = await tx.customer.findFirst({
+        where: { id: customerId, orgId: org.id },
+        select: { id: true }
+      });
+      if (!customer) {
+        throw new Error("CUSTOMER_NOT_FOUND");
+      }
+      const lines: any[] = [];
+      for (const item of items) {
+        if (item.itemId) {
+          const dbItem = await tx.item.findFirst({
+            where: { id: item.itemId, orgId: org.id }
+          });
+          if (!dbItem) {
+            throw new Error("ITEM_NOT_FOUND");
+          }
+          if (!allowNegativeStock && dbItem.qtyOnHand < item.quantity) {
+            throw new Error("INSUFFICIENT_STOCK");
+          }
+          await tx.item.update({
+            where: { id: dbItem.id },
+            data: { qtyOnHand: dbItem.qtyOnHand - item.quantity }
+          });
+          let taxCodeId = item.taxCodeId ?? dbItem.taxCodeId ?? undefined;
+          if (taxCodeId) {
+            const tc = await tx.taxCode.findFirst({
+              where: { id: taxCodeId, orgId: org.id },
+              select: { id: true }
+            });
+            if (!tc) {
+              throw new Error("TAXCODE_NOT_FOUND");
+            }
+            taxCodeId = tc.id;
+          }
+          lines.push({
+            itemId: dbItem.id,
+            description: item.description ?? dbItem.description,
+            quantity: item.quantity,
+            unitPrice: new Prisma.Decimal(item.unitPrice ?? dbItem.price),
+            taxCodeId: taxCodeId
+          });
+          continue;
+        }
+        let manualTaxCodeId = item.taxCodeId;
+        if (manualTaxCodeId) {
+          const tc = await tx.taxCode.findFirst({
+            where: { id: manualTaxCodeId, orgId: org.id },
+            select: { id: true }
+          });
+          if (!tc) {
+            throw new Error("TAXCODE_NOT_FOUND");
+          }
+          manualTaxCodeId = tc.id;
+        }
+        lines.push({
+          description: item.description ?? "",
+          quantity: item.quantity,
+          unitPrice: new Prisma.Decimal(item.unitPrice ?? 0),
+          taxCodeId: manualTaxCodeId
+        });
+      }
+      return tx.invoice.create({
+        data: {
+          orgId: org.id,
+          customerId: customer.id,
+          number,
+          lines: { create: lines }
+        },
+        include: { lines: true, customer: true }
+      });
     });
+    await notifyWebhook(org.id, "invoice.created", invoice);
+    return NextResponse.json(invoice);
+  } catch (err: any) {
+    if (
+      err.message === "ITEM_NOT_FOUND" ||
+      err.message === "TAXCODE_NOT_FOUND" ||
+      err.message === "CUSTOMER_NOT_FOUND"
+    ) {
+      return new NextResponse("Not found", { status: 404 });
+    }
+    if (err.message === "INSUFFICIENT_STOCK") {
+      return new NextResponse("Insufficient stock", { status: 400 });
+    }
+    throw err;
   }
-  const invoice = await prisma.invoice.create({
-    data: {
-      orgId: org.id,
-      customerId: customer.id,
-      number,
-      lines: { create: lines }
-    },
-    include: { lines: true, customer: true }
-  });
-  await notifyWebhook(org.id, "invoice.created", invoice);
-  return NextResponse.json(invoice);
 }


### PR DESCRIPTION
## Summary
- ensure invoice creation uses customer/item/taxCode scoped to org inside a transaction
- tighten v1 invoice API with stock adjustments and org scoping

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5b648f6a88329b88daf20a1e1518d