### PR TITLE
feat(payment): add method and receipt number

### DIFF
--- a/prisma/migrations/20250831190000_add_payment_fields/migration.sql
+++ b/prisma/migrations/20250831190000_add_payment_fields/migration.sql
@@ -1,0 +1,3 @@
+-- Alter Payment to include method and receiptNumber
+ALTER TABLE "Payment" ADD COLUMN "method" TEXT NOT NULL;
+ALTER TABLE "Payment" ADD COLUMN "receiptNumber" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,6 +201,8 @@ model Payment {
   invoiceId        String
   orgId            String
   amount           Decimal           @db.Decimal(10, 2)
+  method           String
+  receiptNumber    Int
   date             DateTime          @default(now())
   invoice          Invoice           @relation(fields: [invoiceId, orgId], references: [id, orgId])
   bankTransactions BankTransaction[]

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -45,6 +45,7 @@ export async function POST(req: Request) {
   const payment = await prisma.payment.create({
     data: {
       invoiceId,
+      orgId: userOrg.orgId,
       amount: new Prisma.Decimal(amount),
       method,
       receiptNumber: number


### PR DESCRIPTION
## Summary
- extend `Payment` model with `method` and `receiptNumber`
- include `orgId` when creating payments via API
- add migration and regenerate Prisma client

## Testing
- `pnpm prisma migrate dev --name add-payment-fields --create-only` *(fails: Can't reach database server at `localhost:5432`)*
- `pnpm prisma generate`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba9685e48329aa0e6987a566490b