### PR TITLE
feat: add webhook url to org settings

### DIFF
--- a/prisma/migrations/20250901160000_add_webhook_url/migration.sql
+++ b/prisma/migrations/20250901160000_add_webhook_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "OrgSettings" ADD COLUMN "webhookUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,7 @@ model OrgSettings {
   brandHex           String? // primary color for theming
   allowNegativeStock Boolean @default(false)
   apiKey             String? @unique
+  webhookUrl         String?
 }
 
 model UserOrg {


### PR DESCRIPTION
## Summary
- add optional `webhookUrl` to `OrgSettings`
- create migration for webhook url

## Testing
- `npx prisma migrate dev --name add-webhook-url --create-only` *(fails: Can't reach database server at `localhost:5432`)*
- `npx prisma generate`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba935be48329924ee6e7916aad75