### PR TITLE
fix: handle payment defaults and runtime prisma cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tailwind-merge": "^2.5.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "prisma": "^5.18.0"
   },
   "devDependencies": {
     "@types/node": "24.3.0",
@@ -36,7 +37,6 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
     "postcss": "^8.4.41",
-    "prisma": "^5.18.0",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       pdfkit:
         specifier: ^0.17.2
         version: 0.17.2
+      prisma:
+        specifier: ^5.18.0
+        version: 5.22.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -81,9 +84,6 @@ importers:
       postcss:
         specifier: ^8.4.41
         version: 8.5.6
-      prisma:
-        specifier: ^5.18.0
-        version: 5.22.0
       tailwindcss:
         specifier: ^3.4.10
         version: 3.4.17

--- a/prisma/migrations/20250831190000_add_payment_fields/migration.sql
+++ b/prisma/migrations/20250831190000_add_payment_fields/migration.sql
@@ -1,3 +1,12 @@
 -- Alter Payment to include method and receiptNumber
-ALTER TABLE "Payment" ADD COLUMN "method" TEXT NOT NULL;
-ALTER TABLE "Payment" ADD COLUMN "receiptNumber" INTEGER NOT NULL;
+-- Add as nullable to avoid issues with existing rows
+ALTER TABLE "Payment" ADD COLUMN "method" TEXT;
+ALTER TABLE "Payment" ADD COLUMN "receiptNumber" INTEGER;
+
+-- Populate existing rows with sensible defaults
+UPDATE "Payment" SET "method" = 'cash' WHERE "method" IS NULL;
+UPDATE "Payment" SET "receiptNumber" = 1 WHERE "receiptNumber" IS NULL;
+
+-- Ensure columns are required for future records
+ALTER TABLE "Payment" ALTER COLUMN "method" SET NOT NULL;
+ALTER TABLE "Payment" ALTER COLUMN "receiptNumber" SET NOT NULL;


### PR DESCRIPTION
## Summary
- add payment columns as nullable, populate defaults, then enforce not-null
- make `prisma` a runtime dependency so `pnpm start` can run migrations

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc30b3808329b1a4116d9ddcb10d