### PR TITLE
Check user ID in bank import API route

### DIFF
--- a/src/app/api/bank/import/route.ts
+++ b/src/app/api/bank/import/route.ts
@@ -7,12 +7,13 @@ import Papa from "papaparse";
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  const userId = (session?.user as { id?: string })?.id;
+  if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {


### PR DESCRIPTION
## Summary
- Validate that the bank import API has a logged-in user and return 401 if missing
- Use the verified user ID for organization lookup

## Testing
- `pnpm build` *(fails: Type error in src/app/api/bank/reconcile/route.ts: 'session.user' is possibly 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68b5cc23f71c8329b91432139b123be1