### PR TITLE
Guard session user ids in API routes

### DIFF
--- a/src/app/api/bank/reconcile/route.ts
+++ b/src/app/api/bank/reconcile/route.ts
@@ -5,11 +5,12 @@ import { prisma } from "@/lib/prisma";
 
 export async function POST() {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/bank/transactions/route.ts
+++ b/src/app/api/bank/transactions/route.ts
@@ -5,11 +5,12 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/bills/route.ts
+++ b/src/app/api/bills/route.ts
@@ -13,9 +13,10 @@ interface BillLineInput {
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) return new NextResponse("Unauthorized", { status: 401 });
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) return new NextResponse("No organization", { status: 400 });
@@ -40,9 +41,10 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) return new NextResponse("Unauthorized", { status: 401 });
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) return new NextResponse("No organization", { status: 400 });

--- a/src/app/api/email/send-invoice/route.ts
+++ b/src/app/api/email/send-invoice/route.ts
@@ -10,11 +10,12 @@ import path from "path";
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/email/send-receipt/route.ts
+++ b/src/app/api/email/send-receipt/route.ts
@@ -10,11 +10,12 @@ import path from "path";
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/estimates/[id]/convert/route.ts
+++ b/src/app/api/estimates/[id]/convert/route.ts
@@ -10,11 +10,12 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/estimates/route.ts
+++ b/src/app/api/estimates/route.ts
@@ -14,11 +14,12 @@ interface EstimateItemInput {
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {
@@ -33,11 +34,12 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/invoices/[id]/pdf/route.ts
+++ b/src/app/api/invoices/[id]/pdf/route.ts
@@ -11,12 +11,13 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -16,11 +16,12 @@ interface InvoiceItemInput {
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {
@@ -35,11 +36,12 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -15,12 +15,13 @@ const PaymentSchema = z.object({
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/receipts/[paymentId]/pdf/route.ts
+++ b/src/app/api/receipts/[paymentId]/pdf/route.ts
@@ -11,11 +11,12 @@ export async function GET(
   { params }: { params: { paymentId: string } }
 ) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {

--- a/src/app/api/reports/ar-aging/route.ts
+++ b/src/app/api/reports/ar-aging/route.ts
@@ -5,9 +5,10 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) return new NextResponse("Unauthorized", { status: 401 });
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) return new NextResponse("No organization", { status: 400 });

--- a/src/app/api/reports/vat-summary/route.ts
+++ b/src/app/api/reports/vat-summary/route.ts
@@ -5,9 +5,10 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) return new NextResponse("Unauthorized", { status: 401 });
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) return new NextResponse("No organization", { status: 400 });

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -5,11 +5,12 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {
@@ -23,11 +24,12 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
-  if (!session) {
+  if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  const userId = session.user.id;
   const userOrg = await prisma.userOrg.findFirst({
-    where: { userId: session.user.id },
+    where: { userId },
     select: { orgId: true }
   });
   if (!userOrg) {


### PR DESCRIPTION
## Summary
- Guard access to all session user ids in API routes using non-null checks and return 401 when absent
- Use extracted `userId` variable in downstream Prisma queries

## Testing
- `pnpm build` *(fails: Could not find a declaration file for module 'papaparse')*

------
https://chatgpt.com/codex/tasks/task_e_68b5cf4224248329b51c229d728ed8ba