### PR TITLE
Avoid bundling mjml in client code

### DIFF
--- a/src/app/api/email/send-invoice/route.ts
+++ b/src/app/api/email/send-invoice/route.ts
@@ -43,11 +43,14 @@ export async function POST(req: Request) {
     const vat = line * (l.taxCode?.rate || 0);
     return sum + line + vat;
   }, 0);
-  const html = invoiceTemplate({
-    number: invoice.number,
-    issueDate: invoice.issueDate,
-    total
-  });
+  const { default: mjml2html } = (eval("require")("mjml") as typeof import("mjml"));
+  const html = mjml2html(
+    invoiceTemplate({
+      number: invoice.number,
+      issueDate: invoice.issueDate,
+      total
+    })
+  ).html;
   await sendMail({
     to: invoice.customer.email,
     subject: `Invoice #${invoice.number}`,

--- a/src/app/api/email/send-receipt/route.ts
+++ b/src/app/api/email/send-receipt/route.ts
@@ -34,11 +34,14 @@ export async function POST(req: Request) {
     logo = fs.readFileSync(path.join(process.cwd(), "public", "logo.svg"));
   } catch {}
   const pdf = await receiptPdf(payment, logo);
-  const html = receiptTemplate({
-    receiptNumber: payment.receiptNumber,
-    date: payment.date,
-    amount: Number(payment.amount)
-  });
+  const { default: mjml2html } = (eval("require")("mjml") as typeof import("mjml"));
+  const html = mjml2html(
+    receiptTemplate({
+      receiptNumber: payment.receiptNumber,
+      date: payment.date,
+      amount: Number(payment.amount)
+    })
+  ).html;
   await sendMail({
     to: payment.invoice.customer.email,
     subject: `Receipt #${payment.receiptNumber}`,

--- a/src/emails/templates.ts
+++ b/src/emails/templates.ts
@@ -1,4 +1,3 @@
-import mjml2html from "mjml";
 import { fmtMoney, fmtDate } from "@/lib/format";
 
 export function invoiceTemplate(invoice: {
@@ -6,7 +5,7 @@ export function invoiceTemplate(invoice: {
   issueDate?: string | Date;
   total: number;
 }) {
-  const { html } = mjml2html(`
+  return `
     <mjml>
       <mj-body>
         <mj-section>
@@ -18,8 +17,7 @@ export function invoiceTemplate(invoice: {
         </mj-section>
       </mj-body>
     </mjml>
-  `);
-  return html;
+  `;
 }
 
 export function receiptTemplate(payment: {
@@ -27,7 +25,7 @@ export function receiptTemplate(payment: {
   date: string | Date;
   amount: number;
 }) {
-  const { html } = mjml2html(`
+  return `
     <mjml>
       <mj-body>
         <mj-section>
@@ -39,6 +37,5 @@ export function receiptTemplate(payment: {
         </mj-section>
       </mj-body>
     </mjml>
-  `);
-  return html;
+  `;
 }


### PR DESCRIPTION
## Summary
- return raw MJML strings from invoice and receipt templates
- load mjml at runtime inside API routes so only Node.js environments require it

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Property 'id' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d3cac7c8832996864dc06c050ba0