### PR TITLE
Add NextAuth session user id typing

### DIFF
--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,12 @@
+import NextAuth from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+    };
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   },
   "include": [
     "next-env.d.ts",
+    "src/types/**/*.d.ts",
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts"


### PR DESCRIPTION
## Summary
- define user object with required id on NextAuth session
- include custom type declarations in TypeScript config

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Argument of type ... invoicePdf (customer property is incompatible))*

------
https://chatgpt.com/codex/tasks/task_e_68b5d91af2788329bb92110463d76898