### PR TITLE
Handle nullable customers in invoice PDF

### DIFF
--- a/src/app/api/email/send-invoice/route.ts
+++ b/src/app/api/email/send-invoice/route.ts
@@ -37,7 +37,22 @@ export async function POST(req: Request) {
   try {
     logo = fs.readFileSync(path.join(process.cwd(), "public", "logo.svg"));
   } catch {}
-  const pdf = await invoicePdf(invoice, logo);
+  const pdf = await invoicePdf(
+    {
+      number: invoice.number,
+      issueDate: invoice.issueDate ?? undefined,
+      customer: invoice.customer
+        ? { name: invoice.customer.name, email: invoice.customer.email || undefined }
+        : null,
+      lines: invoice.lines.map((l) => ({
+        description: l.description || "",
+        quantity: l.quantity,
+        unitPrice: Number(l.unitPrice),
+        taxCode: l.taxCode ? { rate: l.taxCode.rate } : undefined
+      }))
+    },
+    logo
+  );
   const total = invoice.lines.reduce((sum, l) => {
     const line = l.quantity * Number(l.unitPrice);
     const vat = line * (l.taxCode?.rate || 0);

--- a/src/app/api/email/send-receipt/route.ts
+++ b/src/app/api/email/send-receipt/route.ts
@@ -33,7 +33,16 @@ export async function POST(req: Request) {
   try {
     logo = fs.readFileSync(path.join(process.cwd(), "public", "logo.svg"));
   } catch {}
-  const pdf = await receiptPdf(payment, logo);
+  const pdf = await receiptPdf(
+    {
+      receiptNumber: payment.receiptNumber,
+      date: payment.date,
+      invoice: payment.invoice ? { number: payment.invoice.number } : undefined,
+      amount: Number(payment.amount),
+      method: payment.method
+    },
+    logo
+  );
   const { default: mjml2html } = (eval("require")("mjml") as typeof import("mjml"));
   const html = mjml2html(
     receiptTemplate({

--- a/src/app/api/invoices/[id]/pdf/route.ts
+++ b/src/app/api/invoices/[id]/pdf/route.ts
@@ -36,8 +36,23 @@ export async function GET(
   try {
     logo = fs.readFileSync(path.join(process.cwd(), "public", "logo.svg"));
   } catch {}
-  const pdf = await invoicePdf(invoice, logo);
-  return new NextResponse(pdf, {
+  const pdf = await invoicePdf(
+    {
+      number: invoice.number,
+      issueDate: invoice.issueDate ?? undefined,
+      customer: invoice.customer
+        ? { name: invoice.customer.name, email: invoice.customer.email || undefined }
+        : null,
+      lines: invoice.lines.map((l) => ({
+        description: l.description || "",
+        quantity: l.quantity,
+        unitPrice: Number(l.unitPrice),
+        taxCode: l.taxCode ? { rate: l.taxCode.rate } : undefined
+      }))
+    },
+    logo
+  );
+  return new NextResponse(pdf as any, {
     headers: { "Content-Type": "application/pdf" }
   });
 }

--- a/src/app/api/receipts/[paymentId]/pdf/route.ts
+++ b/src/app/api/receipts/[paymentId]/pdf/route.ts
@@ -33,8 +33,17 @@ export async function GET(
   try {
     logo = fs.readFileSync(path.join(process.cwd(), "public", "logo.svg"));
   } catch {}
-  const pdf = await receiptPdf(payment, logo);
-  return new NextResponse(pdf, {
+  const pdf = await receiptPdf(
+    {
+      receiptNumber: payment.receiptNumber,
+      date: payment.date,
+      invoice: payment.invoice ? { number: payment.invoice.number } : undefined,
+      amount: Number(payment.amount),
+      method: payment.method
+    },
+    logo
+  );
+  return new NextResponse(pdf as any, {
     headers: { "Content-Type": "application/pdf" }
   });
 }

--- a/src/lib/invoicePdf.ts
+++ b/src/lib/invoicePdf.ts
@@ -4,7 +4,7 @@ import { fmtMoney, fmtDate } from "@/lib/format";
 interface InvoiceLike {
   number: number;
   issueDate?: string | Date;
-  customer?: { name: string; email?: string };
+  customer?: { name: string; email?: string } | null;
   lines: Array<{
     description: string;
     quantity: number;

--- a/src/types/mjml.d.ts
+++ b/src/types/mjml.d.ts
@@ -1,0 +1,2 @@
+declare module "mjml";
+declare module "bcrypt";


### PR DESCRIPTION
## Summary
- Allow invoices without customer details when generating PDFs
- Sanitize invoice and receipt data before PDF generation and email delivery
- Add type declarations for modules lacking TypeScript definitions

## Testing
- `pnpm build` *(fails: Type error in src/app/api/v1/payments/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dcd5ac148329bd199cb5ccbaa0e4