### PR TITLE
Backfill new columns and enforce composite relations

### DIFF
--- a/prisma/migrations/20250831174029_composite_fks/migration.sql
+++ b/prisma/migrations/20250831174029_composite_fks/migration.sql
@@ -103,6 +103,7 @@ UPDATE "OrgSettings" SET "id" = uuid_generate_v4();
 
 -- enforce id constraints
 ALTER TABLE "OrgSettings" ALTER COLUMN "id" SET NOT NULL;
+ALTER TABLE "OrgSettings" ALTER COLUMN "id" SET DEFAULT uuid_generate_v4();
 
 ALTER TABLE "OrgSettings" ADD CONSTRAINT "OrgSettings_pkey" PRIMARY KEY ("id");
 
@@ -120,6 +121,7 @@ UPDATE "User" SET "updatedAt" = CURRENT_TIMESTAMP WHERE "updatedAt" IS NULL;
 -- enforce updatedAt constraints
 ALTER TABLE "User"
   ALTER COLUMN "updatedAt" SET NOT NULL;
+ALTER TABLE "User" ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP;
 
 -- AlterTable
 -- migrate existing string roles to enum values via a temporary column

--- a/prisma/migrations/20250901212511_apply_composite_fks/migration.sql
+++ b/prisma/migrations/20250901212511_apply_composite_fks/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[orgId,name]` on the table `Vendor` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "qtyOnHand" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Vendor_orgId_name_key" ON "Vendor"("orgId", "name");


### PR DESCRIPTION
## Summary
- Ensure OrgSettings.id and User.updatedAt columns are backfilled then marked NOT NULL
- Add default UUID and timestamp values for new records
- Capture missing migration for Item.qtyOnHand and unique Vendor org/name index

## Testing
- `pnpm prisma migrate dev --name apply-composite-fks`
- `pnpm prisma generate`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60e5a1b9c8329bde4edebf9483b7c