### PR TITLE
Apply OrgSettings and User default values

### DIFF
--- a/prisma/migrations/20250915000000_apply_orgsettings_user_defaults/migration.sql
+++ b/prisma/migrations/20250915000000_apply_orgsettings_user_defaults/migration.sql
@@ -1,0 +1,11 @@
+-- Ensure extension for gen_random_uuid
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Alter OrgSettings.id to use gen_random_uuid and enforce NOT NULL
+ALTER TABLE "OrgSettings"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN "id" SET NOT NULL;
+
+-- Set default value for User.updatedAt
+ALTER TABLE "User"
+  ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model User {
   sessions      Session[]
   memberships   UserOrg[]
   createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  updatedAt     DateTime  @default(now()) @updatedAt
 }
 
 model Org {
@@ -48,7 +48,7 @@ model Org {
 }
 
 model OrgSettings {
-  id                 String  @id @default(cuid())
+  id                 String  @id @default(dbgenerated("gen_random_uuid()"))
   orgId              String  @unique
   org                Org     @relation(fields: [orgId], references: [id])
   brandHex           String? // primary color for theming


### PR DESCRIPTION
## Summary
- default `OrgSettings.id` to `gen_random_uuid()`
- ensure `User.updatedAt` uses `CURRENT_TIMESTAMP`

## Testing
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/herobooks" npx prisma migrate dev --name apply_orgsettings_user_defaults` *(fails: P1001 Can't reach database server)*
- `npx prisma generate`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b622bfc4008329880475d4b64c7405