### PR TITLE
Fix email receipt endpoint to accept JSON body

### DIFF
--- a/src/app/api/email/send-receipt/route.ts
+++ b/src/app/api/email/send-receipt/route.ts
@@ -21,8 +21,7 @@ export async function POST(req: Request) {
   if (!userOrg) {
     return new NextResponse("No organization", { status: 400 });
   }
-  const form = await req.formData();
-  const paymentId = form.get("paymentId")?.toString();
+  const { paymentId } = await req.json();
   if (!paymentId) {
     return new NextResponse("Missing paymentId", { status: 400 });
   }


### PR DESCRIPTION
## Summary
- parse JSON body in `/api/email/send-receipt`

## Testing
- `pnpm lint`
- `curl -s -D - -H "Content-Type: application/json" -d '{"paymentId":"test"}' http://localhost:3000/api/email/send-receipt` *(fails: 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_68b622c629a08329826fb57e44bf8824