### PR TITLE
chore: run prisma generate once per build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "packageManager": "pnpm@10.5.2",
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "next build",
     "start": "prisma migrate deploy && next start",
     "postinstall": "prisma generate",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- avoid generating Prisma client twice by running it only via postinstall

## Testing
- `pnpm install`
- `pnpm build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b653a9c1288329b30286fc03079ae3