### PR TITLE
fix: restore VAT report and conditional org cookie

### DIFF
--- a/src/app/(app)/reports/vat/page.tsx
+++ b/src/app/(app)/reports/vat/page.tsx
@@ -1,3 +1,27 @@
-export default function VatReportPage() {
-  return <div className="text-sm">VAT Summary — TODO: input/output tax by period, return export.</div>;
+import { fmtMoney } from "@/lib/format";
+
+export default async function VatReportPage() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/reports/vat-summary`, {
+    cache: "no-store",
+  });
+  const data = await res.json();
+  return (
+    <div>
+      <h1 className="text-xl mb-4">VAT Summary</h1>
+      <div className="grid grid-cols-3 gap-4 mb-8">
+        <div className="p-4 border rounded">
+          <div className="font-semibold">Output VAT</div>
+          <div>{fmtMoney(data.outputVat)}</div>
+        </div>
+        <div className="p-4 border rounded">
+          <div className="font-semibold">Input VAT</div>
+          <div>{fmtMoney(data.inputVat)}</div>
+        </div>
+        <div className="p-4 border rounded">
+          <div className="font-semibold">Net VAT</div>
+          <div>{fmtMoney(data.netVat)}</div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/api/org/switch/route.ts
+++ b/src/app/api/org/switch/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     httpOnly: true,
     sameSite: "lax",
     path: "/",
-    secure: true,
+    secure: process.env.NODE_ENV === "production",
     maxAge: 60 * 60 * 24 * 365,
   });
 


### PR DESCRIPTION
## Summary
- set org switch cookie's `secure` flag only in production
- restore VAT report page to fetch and display VAT summary data

## Testing
- `pnpm lint`
- `pnpm dlx prisma migrate dev -n "rev2_layout_theme"` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b6663452a483299399679f98d592c9