### PR TITLE
feat: add multi-provider checkout and PayPal integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,24 @@ IMAP_USER=
 IMAP_PASSWORD=
 IMAP_TLS=true
 EMAIL_INGEST_SECRET=
+
+# PayPal (server-side)
+PAYPAL_ENV=sandbox            # "live" or "sandbox"
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
+# For rough USD conversion if charging in USD via PayPal (GYD→USD rate, approx)
+PAYPAL_GYD_PER_USD=200
+
+# Zelle (manual) — show these on the instruction page
+ZELLE_HANDLE=your-zelle-email@example.com
+
+# MMG (QR / hosted)
+MMG_BASE_URL=https://uat-developer.mmg.gy
+MMG_MERCHANT_ID=
+MMG_API_KEY=
+MMG_CHECKOUT_PATH=/api/checkout
+MMG_WEBHOOK_SECRET=
+
+# Bank transfer (manual)
+BANK_NAME=
+BANK_ACCOUNT=

--- a/prisma/migrations/20250916000000_rev2_providers_paypal_zelle_mmg_bank/migration.sql
+++ b/prisma/migrations/20250916000000_rev2_providers_paypal_zelle_mmg_bank/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "CheckoutIntent" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "plan" TEXT NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'GYD',
+    "amount" INTEGER NOT NULL,
+    "discount" INTEGER NOT NULL DEFAULT 0,
+    "promoCode" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'created',
+    "paymentMethod" TEXT,
+    "externalRef" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CheckoutIntent_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "CheckoutIntent" ADD CONSTRAINT "CheckoutIntent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -332,3 +332,19 @@ model UserPreference {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model CheckoutIntent {
+  id            String   @id @default(cuid())
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId        String
+  plan          String
+  currency      String   @default("GYD")
+  amount        Int
+  discount      Int      @default(0)
+  promoCode     String?
+  status        String   @default("created") // created|processing|paid|failed|cancelled
+  paymentMethod String?  // "paypal" | "zelle" | "mmg" | "bank"
+  externalRef   String?  // PSP order/transaction reference
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}

--- a/src/app/(marketing)/checkout/bank/page.tsx
+++ b/src/app/(marketing)/checkout/bank/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+
+export default async function BankInstructionsPage({ searchParams }: { searchParams: Record<string, string | string[] | undefined> }) {
+  const intent = (Array.isArray(searchParams?.intent) ? searchParams.intent[0] : searchParams?.intent) ?? "";
+  const rec = intent ? await prisma.checkoutIntent.findUnique({ where: { id: intent } }) : null;
+
+  return (
+    <section className="container mx-auto px-4 py-12 max-w-2xl">
+      <h1 className="text-2xl font-semibold">Bank Transfer (EFT/RTGS)</h1>
+      <p className="text-sm text-muted-foreground mt-1">Use the reference below so we can match your payment automatically.</p>
+
+      <div className="rounded-xl border p-6 mt-6 grid gap-3 text-sm">
+        <div className="flex items-center justify-between"><span>Reference</span><code className="font-mono">{intent || "—"}</code></div>
+        <div className="flex items-center justify-between"><span>Payee</span><span>heroBooks (HeroCart Inc.)</span></div>
+        <div className="flex items-center justify-between"><span>Bank</span><span>{process.env.BANK_NAME ?? "—"}</span></div>
+        <div className="flex items-center justify-between"><span>Account #</span><span>{process.env.BANK_ACCOUNT ?? "—"}</span></div>
+        <div className="flex items-center justify-between"><span>Amount (GYD)</span><span>{rec ? `GYD $${rec.amount.toLocaleString()}` : "See checkout"}</span></div>
+        <p className="text-xs text-muted-foreground">
+          Email your transfer confirmation to <a className="underline" href="mailto:billing@herobooks.net">billing@herobooks.net</a>. Activation occurs after funds are received.
+        </p>
+      </div>
+
+      <div className="mt-6 flex items-center gap-3">
+        <Link href="/pricing" className="rounded-md border px-4 py-2 text-sm">Back to pricing</Link>
+        <Link href="/checkout" className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm">Use a different method</Link>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(marketing)/checkout/page.tsx
+++ b/src/app/(marketing)/checkout/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo, useState } from "react";
+import { normalizePlan, type Plan } from "@/lib/plans";
+
+const PRICES: Record<Plan, number> = { starter: 0, business: 9900, enterprise: 0 };
+
+export default function CheckoutPage() {
+  const router = useRouter();
+  const sp = useSearchParams();
+  const initialPlan = normalizePlan(sp.get("plan"));
+  const [plan, setPlan] = useState<Plan>(initialPlan);
+  const [promo, setPromo] = useState<string>("GYA-LAUNCH");
+  const [method, setMethod] = useState<"paypal" | "zelle" | "mmg" | "bank">("paypal");
+  const [submitting, setSubmitting] = useState(false);
+
+  const base = PRICES[plan];
+  const { final, discount } = useMemo(() => {
+    const code = (promo ?? "").trim().toUpperCase();
+    if (base && code === "GYA-LAUNCH") {
+      const d = Math.round(base * 0.5);
+      return { final: base - d, discount: d };
+    }
+    return { final: base, discount: 0 };
+  }, [base, promo]);
+
+  function formatGYD(n: number) {
+    try { return new Intl.NumberFormat(undefined, { style: "currency", currency: "GYD", maximumFractionDigits: 0 }).format(n); }
+    catch { return `GYD $${n.toLocaleString()}`; }
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/subscribe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan, promoCode: promo, paymentMethod: method }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error ?? "Checkout failed");
+      router.push(data.redirectUrl);
+    } catch (err) {
+      alert((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="container mx-auto px-4 py-12 max-w-lg">
+      <h1 className="text-2xl font-semibold">Checkout</h1>
+      <form onSubmit={onSubmit} className="mt-6 space-y-6">
+        {/* Plan */}
+        <fieldset className="rounded-xl border p-4">
+          <legend className="text-sm font-medium px-1">Plan</legend>
+          <div className="mt-3 grid gap-2">
+            {(["starter", "business", "enterprise"] as Plan[]).map((p) => (
+              <label key={p} className="flex items-center justify-between gap-2 text-sm">
+                <span className="capitalize">{p}</span>
+                <div className="flex items-center gap-3">
+                  <span className="text-muted-foreground">{formatGYD(PRICES[p])}{p === "enterprise" && " (sales)"}</span>
+                  <input type="radio" name="plan" value={p} checked={plan === p} onChange={() => setPlan(p)} />
+                </div>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {/* Payment method */}
+        <fieldset className="rounded-xl border p-4">
+          <legend className="text-sm font-medium px-1">Payment method</legend>
+          <div className="mt-3 grid gap-2">
+            <label className="flex items-center justify-between gap-2 text-sm">
+              <span>PayPal</span>
+              <input type="radio" name="method" value="paypal" checked={method === "paypal"} onChange={() => setMethod("paypal")} />
+            </label>
+            <label className="flex items-center justify-between gap-2 text-sm">
+              <span>Zelle (manual confirm)</span>
+              <input type="radio" name="method" value="zelle" checked={method === "zelle"} onChange={() => setMethod("zelle")} />
+            </label>
+            <label className="flex items-center justify-between gap-2 text-sm">
+              <span>MMG (QR)</span>
+              <input type="radio" name="method" value="mmg" checked={method === "mmg"} onChange={() => setMethod("mmg")} />
+            </label>
+            <label className="flex items-center justify-between gap-2 text-sm">
+              <span>Bank transfer (EFT/RTGS)</span>
+              <input type="radio" name="method" value="bank" checked={method === "bank"} onChange={() => setMethod("bank")} />
+            </label>
+          </div>
+        </fieldset>
+
+        {/* Promo */}
+        <div className="grid gap-2">
+          <label className="text-sm">Promo code</label>
+          <input value={promo} onChange={(e) => setPromo(e.target.value)} className="rounded-md border bg-background px-3 py-2 text-sm" />
+          <p className="text-xs text-muted-foreground">Use <b>GYA-LAUNCH</b> for 50% off first 2 months (Business).</p>
+        </div>
+
+        {/* Summary */}
+        <div className="rounded-xl border p-4 bg-card text-sm">
+          <div className="flex items-center justify-between"><span>Subtotal</span><span>{formatGYD(base)}</span></div>
+          <div className="flex items-center justify-between"><span>Discount</span><span>− {formatGYD(discount)}</span></div>
+          <div className="mt-2 border-t pt-2 flex items-center justify-between font-medium">
+            <span>Total due today</span><span>{formatGYD(final)}</span>
+          </div>
+        </div>
+
+        <button disabled={submitting || plan === "enterprise"} className="w-full rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium disabled:opacity-60">
+          {plan === "enterprise" ? "Contact sales" : submitting ? "Processing…" : "Proceed"}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/app/(marketing)/checkout/zelle/page.tsx
+++ b/src/app/(marketing)/checkout/zelle/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { prisma } from "@/lib/prisma";
+
+export default async function ZelleInstructionsPage({ searchParams }: { searchParams: Record<string, string | string[] | undefined> }) {
+  const intent = (Array.isArray(searchParams?.intent) ? searchParams.intent[0] : searchParams?.intent) ?? "";
+  const rec = intent ? await prisma.checkoutIntent.findUnique({ where: { id: intent } }) : null;
+
+  return (
+    <section className="container mx-auto px-4 py-12 max-w-2xl">
+      <h1 className="text-2xl font-semibold">Pay with Zelle</h1>
+      <p className="text-sm text-muted-foreground mt-1">Send your payment using the reference below, then we’ll confirm and activate your plan.</p>
+
+      <div className="rounded-xl border p-6 mt-6 grid gap-3 text-sm">
+        <div className="flex items-center justify-between"><span>Reference</span><code className="font-mono">{intent || "—"}</code></div>
+        <div className="flex items-center justify-between"><span>Zelle to</span><span>{process.env.ZELLE_HANDLE ?? "your-zelle-email@example.com"}</span></div>
+        <div className="flex items-center justify-between"><span>Amount (GYD)</span><span>{rec ? `GYD $${rec.amount.toLocaleString()}` : "See checkout"}</span></div>
+        <p className="text-xs text-muted-foreground">
+          After sending, email a screenshot or confirmation to <a className="underline" href="mailto:billing@herobooks.net">billing@herobooks.net</a> with the reference above. We’ll mark it paid promptly.
+        </p>
+      </div>
+
+      <div className="mt-6 flex items-center gap-3">
+        <Link href="/pricing" className="rounded-md border px-4 py-2 text-sm">Back to pricing</Link>
+        <Link href="/checkout" className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm">Use a different method</Link>
+      </div>
+    </section>
+  );
+}

--- a/src/app/api/paypal/capture/route.ts
+++ b/src/app/api/paypal/capture/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const PAYPAL_BASE =
+  process.env.PAYPAL_ENV === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const token = url.searchParams.get("token"); // PayPal order ID
+  const intentId = url.searchParams.get("intent") || "";
+
+  if (!token || !intentId) return NextResponse.redirect(new URL(`/checkout/confirm?id=${intentId}`, url).toString());
+
+  // Capture the order
+  // We use client creds again for simplicity
+  const creds = Buffer.from(
+    `${process.env.PAYPAL_CLIENT_ID}:${process.env.PAYPAL_CLIENT_SECRET}`
+  ).toString("base64");
+  const tokRes = await fetch(`${PAYPAL_BASE}/v1/oauth2/token`, {
+    method: "POST",
+    headers: { Authorization: `Basic ${creds}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body: "grant_type=client_credentials",
+  });
+  const { access_token } = await tokRes.json();
+
+  const capRes = await fetch(`${PAYPAL_BASE}/v2/checkout/orders/${token}/capture`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${access_token}`, "Content-Type": "application/json" },
+  });
+  const capJson = await capRes.json();
+
+  if (capRes.ok) {
+    await prisma.checkoutIntent.update({
+      where: { id: intentId },
+      data: { status: "paid", externalRef: token },
+    });
+  } else {
+    await prisma.checkoutIntent.update({
+      where: { id: intentId },
+      data: { status: "failed" },
+    });
+  }
+
+  return NextResponse.redirect(new URL(`/checkout/confirm?id=${intentId}`, url).toString());
+}

--- a/src/app/api/subscribe/checkout/route.ts
+++ b/src/app/api/subscribe/checkout/route.ts
@@ -1,0 +1,57 @@
+// Updated to route to paypal|zelle|mmg|bank only
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { normalizePlan, type Plan } from "@/lib/plans";
+import { getPlanPriceGyd, applyPromo } from "@/lib/pricing";
+import { getProviderOrThrow } from "@/lib/payments";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { plan: rawPlan, promoCode, paymentMethod = "paypal" } = await req.json?.() ?? {};
+  const plan: Plan = normalizePlan(rawPlan);
+  if (plan === "enterprise") return NextResponse.json({ error: "Contact sales for Enterprise" }, { status: 400 });
+
+  const baseAmount = getPlanPriceGyd(plan);
+  const { finalAmount, discountAmount, promoApplied } = applyPromo(baseAmount, promoCode);
+
+  const intent = await prisma.checkoutIntent.create({
+    data: {
+      userId: session.user.id,
+      plan,
+      amount: finalAmount,
+      discount: discountAmount,
+      promoCode: promoApplied ?? null,
+      status: "created",
+      paymentMethod,
+    },
+  });
+
+  const provider = getProviderOrThrow(String(paymentMethod));
+  const res = await provider.createCheckout({
+    intentId: intent.id,
+    amountGYD: finalAmount,
+    description: `heroBooks ${plan} plan`,
+    returnUrl: `${process.env.NEXTAUTH_URL}/checkout/confirm`,
+    metadata: { plan },
+  });
+
+  if (!res.ok) return NextResponse.json({ error: res.error }, { status: 400 });
+
+  if (res.externalRef) {
+    await prisma.checkoutIntent.update({
+      where: { id: intent.id },
+      data: { externalRef: res.externalRef, status: "processing" },
+    });
+  } else {
+    await prisma.checkoutIntent.update({
+      where: { id: intent.id },
+      data: { status: "processing" },
+    });
+  }
+
+  return NextResponse.json({ ok: true, redirectUrl: res.redirectUrl });
+}

--- a/src/app/api/webhooks/mmg/route.ts
+++ b/src/app/api/webhooks/mmg/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { mmgProvider } from "@/lib/payments/mmg";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const rawBody = await req.text();
+  const parsed = await mmgProvider.verifyAndParseWebhook?.(req, rawBody);
+  if (!parsed?.ok) return NextResponse.json({ error: parsed?.error || "invalid" }, { status: 400 });
+
+  const { intentId, status, externalRef } = parsed;
+  if (!intentId) return NextResponse.json({ error: "Missing intentId" }, { status: 400 });
+
+  await prisma.checkoutIntent.update({
+    where: { id: intentId },
+    data: { status: status === "paid" ? "paid" : status, externalRef: externalRef ?? undefined },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/payments/bank.ts
+++ b/src/lib/payments/bank.ts
@@ -1,0 +1,7 @@
+import { PaymentProvider, CreateCheckoutInput, CreateCheckoutResult } from "./types";
+
+export const bankProvider: PaymentProvider = {
+  async createCheckout(input: CreateCheckoutInput): Promise<CreateCheckoutResult> {
+    return { ok: true, redirectUrl: `/checkout/bank?intent=${encodeURIComponent(input.intentId)}` };
+  },
+};

--- a/src/lib/payments/index.ts
+++ b/src/lib/payments/index.ts
@@ -1,0 +1,18 @@
+import { PaymentProvider } from "./types";
+import { paypalProvider } from "./paypal";
+import { zelleProvider } from "./zelle";
+import { mmgProvider } from "./mmg";
+import { bankProvider } from "./bank";
+
+export const providers: Record<string, PaymentProvider> = {
+  paypal: paypalProvider,
+  zelle: zelleProvider,
+  mmg: mmgProvider,
+  bank: bankProvider,
+};
+
+export function getProviderOrThrow(name: string): PaymentProvider {
+  const p = providers[name];
+  if (!p) throw new Error(`Unknown payment provider: ${name}`);
+  return p;
+}

--- a/src/lib/payments/mmg.ts
+++ b/src/lib/payments/mmg.ts
@@ -1,0 +1,57 @@
+import { PaymentProvider, CreateCheckoutInput, CreateCheckoutResult } from "./types";
+
+// MMG (QR / hosted) — stub; adjust with real docs
+const MMG_BASE = process.env.MMG_BASE_URL ?? "https://uat-developer.mmg.gy";
+const MMG_MERCHANT_ID = process.env.MMG_MERCHANT_ID ?? "";
+const MMG_API_KEY = process.env.MMG_API_KEY ?? "";
+const MMG_CHECKOUT_PATH = process.env.MMG_CHECKOUT_PATH ?? "/api/checkout";
+
+async function postJSON(url: string, body: any, headers: Record<string, string> = {}) {
+  const res = await fetch(url, { method: "POST", headers: { "Content-Type": "application/json", ...headers }, body: JSON.stringify(body) });
+  if (!res.ok) throw new Error(`MMG HTTP ${res.status}`);
+  return res.json();
+}
+
+export const mmgProvider: PaymentProvider = {
+  async createCheckout(input: CreateCheckoutInput): Promise<CreateCheckoutResult> {
+    try {
+      const payload = {
+        merchantId: MMG_MERCHANT_ID,
+        amount: input.amountGYD,
+        currency: "GYD",
+        description: input.description,
+        returnUrl: input.returnUrl,
+        reference: input.intentId, // our internal key
+        mode: "QR", // hint; depends on MMG API
+      };
+      const data = await postJSON(`${MMG_BASE}${MMG_CHECKOUT_PATH}`, payload, { Authorization: `Bearer ${MMG_API_KEY}` });
+
+      const redirectUrl: string = data?.checkoutUrl ?? data?.qrUrl ?? "";
+      const externalRef: string | undefined = data?.transactionId ?? data?.reference;
+      if (!redirectUrl) return { ok: false, error: "No MMG checkout URL" };
+      return { ok: true, redirectUrl, externalRef };
+    } catch (e: any) {
+      return { ok: false, error: e.message ?? "MMG createCheckout failed" };
+    }
+  },
+  async verifyAndParseWebhook(req: Request, rawBody: string) {
+    try {
+      const body = JSON.parse(rawBody || "{}");
+      const statusMap: Record<string, "paid" | "failed" | "cancelled" | "pending"> = {
+        SUCCESS: "paid",
+        FAILED: "failed",
+        CANCELLED: "cancelled",
+        PENDING: "pending",
+      };
+      return {
+        ok: true,
+        externalRef: body?.transactionId ?? body?.reference,
+        intentId: body?.reference,
+        amountGYD: Number(body?.amount) || undefined,
+        status: statusMap[(body?.status ?? "").toUpperCase()] ?? "pending",
+      };
+    } catch (e: any) {
+      return { ok: false, error: e.message ?? "MMG webhook parse error" };
+    }
+  },
+};

--- a/src/lib/payments/paypal.ts
+++ b/src/lib/payments/paypal.ts
@@ -1,0 +1,61 @@
+import { PaymentProvider, CreateCheckoutInput, CreateCheckoutResult } from "./types";
+
+const PAYPAL_BASE =
+  process.env.PAYPAL_ENV === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
+const PAYPAL_CLIENT_ID = process.env.PAYPAL_CLIENT_ID!;
+const PAYPAL_CLIENT_SECRET = process.env.PAYPAL_CLIENT_SECRET!;
+
+// Simple access token helper
+async function getToken() {
+  const creds = Buffer.from(`${PAYPAL_CLIENT_ID}:${PAYPAL_CLIENT_SECRET}`).toString("base64");
+  const res = await fetch(`${PAYPAL_BASE}/v1/oauth2/token`, {
+    method: "POST",
+    headers: { Authorization: `Basic ${creds}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body: "grant_type=client_credentials",
+  });
+  if (!res.ok) throw new Error(`PayPal token HTTP ${res.status}`);
+  return res.json() as Promise<{ access_token: string }>;
+}
+
+export const paypalProvider: PaymentProvider = {
+  async createCheckout(input: CreateCheckoutInput): Promise<CreateCheckoutResult> {
+    try {
+      // PayPal orders are in a PayPal currency; show GYD on site, but we’ll charge USD here (common practice).
+      // If you need strict GYD, keep it manual via Zelle/MMG/Bank.
+      const chargeUSD = Math.ceil((input.amountGYD / (Number(process.env.PAYPAL_GYD_PER_USD) || 200)) * 100) / 100;
+
+      const { access_token } = await getToken();
+      const res = await fetch(`${PAYPAL_BASE}/v2/checkout/orders`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${access_token}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          intent: "CAPTURE",
+          purchase_units: [
+            {
+              reference_id: input.intentId,
+              description: input.description,
+              amount: { currency_code: "USD", value: chargeUSD.toFixed(2) },
+            },
+          ],
+          application_context: {
+            return_url: `${process.env.NEXTAUTH_URL}/api/paypal/capture?intent=${encodeURIComponent(
+              input.intentId
+            )}`,
+            cancel_url: `${process.env.NEXTAUTH_URL}/checkout?cancel=1`,
+            brand_name: "heroBooks",
+            user_action: "PAY_NOW",
+          },
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message || "PayPal order create failed");
+
+      const approval = (data.links || []).find((l: any) => l.rel === "approve")?.href;
+      const orderId = data.id as string | undefined;
+      if (!approval || !orderId) return { ok: false, error: "No PayPal approval link" };
+      return { ok: true, redirectUrl: approval, externalRef: orderId };
+    } catch (e: any) {
+      return { ok: false, error: e.message ?? "PayPal createCheckout failed" };
+    }
+  },
+};

--- a/src/lib/payments/types.ts
+++ b/src/lib/payments/types.ts
@@ -1,0 +1,25 @@
+export type PaymentMethod = "paypal" | "zelle" | "mmg" | "bank";
+
+export type CreateCheckoutInput = {
+  intentId: string;
+  amountGYD: number;     // integer dollars (GYD)
+  description: string;
+  returnUrl: string;     // browser return
+  metadata?: Record<string, string | number>;
+};
+
+export type CreateCheckoutResult =
+  | { ok: true; redirectUrl: string; externalRef?: string }
+  | { ok: false; error: string };
+
+export interface PaymentProvider {
+  createCheckout(input: CreateCheckoutInput): Promise<CreateCheckoutResult>;
+  verifyAndParseWebhook?(req: Request, rawBody: string): Promise<{
+    ok: boolean;
+    externalRef?: string;
+    intentId?: string;
+    amountGYD?: number;
+    status?: "paid" | "failed" | "cancelled" | "pending";
+    error?: string;
+  }>;
+}

--- a/src/lib/payments/zelle.ts
+++ b/src/lib/payments/zelle.ts
@@ -1,0 +1,12 @@
+import { PaymentProvider, CreateCheckoutInput, CreateCheckoutResult } from "./types";
+
+/**
+ * Zelle has no public checkout API — treat like a guided bank transfer:
+ * show your Zelle handle (email/phone) and the reference code (intentId).
+ * You’ll confirm manually when received.
+ */
+export const zelleProvider: PaymentProvider = {
+  async createCheckout(input: CreateCheckoutInput): Promise<CreateCheckoutResult> {
+    return { ok: true, redirectUrl: `/checkout/zelle?intent=${encodeURIComponent(input.intentId)}` };
+  },
+};


### PR DESCRIPTION
## Summary
- add CheckoutIntent model with payment method and external reference
- implement payment providers for PayPal, Zelle, MMG and bank transfer
- expose checkout flow, PayPal capture endpoint, and instruction pages

## Testing
- `pnpm dlx prisma migrate dev -n "rev2_providers_paypal_zelle_mmg_bank"` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b67580d1888329ab1328f630c4dc32