### PR TITLE
feat(admin): add billing manual approvals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,8 @@ MMG_WEBHOOK_SECRET=
 # Bank transfer (manual)
 BANK_NAME=
 BANK_ACCOUNT=
+# Comma-separated emails who can access /admin pages
+ADMIN_EMAILS=you@company.gy,other@company.gy
+
+# Expose admin link in the client UI (optional). The page itself is still server-gated.
+NEXT_PUBLIC_HAS_ADMIN=1

--- a/src/app/(app)/admin/billing/page.tsx
+++ b/src/app/(app)/admin/billing/page.tsx
@@ -1,0 +1,157 @@
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/admin";
+import StatusBadge from "@/components/admin/StatusBadge";
+import MethodBadge from "@/components/admin/MethodBadge";
+import IntentRowActions from "@/components/admin/IntentRowActions";
+import Link from "next/link";
+
+type SearchParams = { q?: string; status?: string; method?: string; page?: string };
+
+export const metadata = { title: "Admin · Billing — heroBooks" };
+
+export default async function AdminBillingPage({ searchParams }: { searchParams: SearchParams }) {
+  const gate = await requireAdmin();
+  if (!gate.ok) {
+    return (
+      <section className="p-6">
+        <h1 className="text-xl font-semibold">Admin · Billing</h1>
+        <p className="text-sm text-muted-foreground mt-2">Access denied ({gate.reason}).</p>
+      </section>
+    );
+  }
+
+  const q = (searchParams.q ?? "").trim();
+  const status = searchParams.status ?? "all";
+  const method = searchParams.method ?? "all";
+  const page = Math.max(1, Number(searchParams.page ?? "1"));
+  const pageSize = 20;
+
+  const where: any = {};
+  if (status !== "all") where.status = status;
+  if (method !== "all") where.paymentMethod = method;
+  if (q) {
+    where.OR = [
+      { id: { contains: q } },
+      { externalRef: { contains: q } },
+      { plan: { contains: q } },
+      { user: { email: { contains: q } } },
+    ];
+  }
+
+  const [rows, total] = await Promise.all([
+    prisma.checkoutIntent.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: { user: { select: { email: true, name: true } } },
+    }),
+    prisma.checkoutIntent.count({ where }),
+  ]);
+
+  const pages = Math.max(1, Math.ceil(total / pageSize));
+
+  return (
+    <section className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Admin · Billing</h1>
+        <Link href="/pricing" className="text-sm underline text-muted-foreground">View pricing</Link>
+      </div>
+
+      {/* Filters */}
+      <form className="grid gap-3 sm:grid-cols-4">
+        <input
+          name="q"
+          defaultValue={q}
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+          placeholder="Search (id, externalRef, plan, email)"
+        />
+        <select name="status" defaultValue={status} className="rounded-md border bg-background px-3 py-2 text-sm">
+          <option value="all">All statuses</option>
+          <option value="created">Created</option>
+          <option value="processing">Processing</option>
+          <option value="paid">Paid</option>
+          <option value="failed">Failed</option>
+          <option value="cancelled">Cancelled</option>
+        </select>
+        <select name="method" defaultValue={method} className="rounded-md border bg-background px-3 py-2 text-sm">
+          <option value="all">All methods</option>
+          <option value="paypal">PayPal</option>
+          <option value="zelle">Zelle</option>
+          <option value="mmg">MMG</option>
+          <option value="bank">Bank</option>
+        </select>
+        <button className="rounded-md bg-primary text-primary-foreground text-sm px-4">Filter</button>
+      </form>
+
+      {/* Table */}
+      <div className="rounded-xl border overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="text-left p-2">Created</th>
+              <th className="text-left p-2">Intent</th>
+              <th className="text-left p-2">User</th>
+              <th className="text-left p-2">Plan</th>
+              <th className="text-left p-2">Amount (GYD)</th>
+              <th className="text-left p-2">Discount</th>
+              <th className="text-left p-2">Method</th>
+              <th className="text-left p-2">External Ref</th>
+              <th className="text-left p-2">Status</th>
+              <th className="text-left p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="p-2 whitespace-nowrap">{new Date(r.createdAt).toLocaleString()}</td>
+                <td className="p-2 font-mono text-xs">{r.id}</td>
+                <td className="p-2">
+                  <div className="flex flex-col">
+                    <span>{r.user?.name ?? "—"}</span>
+                    <span className="text-xs text-muted-foreground">{r.user?.email ?? "—"}</span>
+                  </div>
+                </td>
+                <td className="p-2 capitalize">{r.plan}</td>
+                <td className="p-2">GYD ${r.amount.toLocaleString()}</td>
+                <td className="p-2">GYD ${r.discount.toLocaleString()}</td>
+                <td className="p-2"><MethodBadge method={r.paymentMethod ?? null} /></td>
+                <td className="p-2 font-mono text-xs">{r.externalRef ?? "—"}</td>
+                <td className="p-2"><StatusBadge status={r.status} /></td>
+                <td className="p-2">
+                  {/* Only show manual actions for non-PayPal or unpaid */}
+                  {r.status !== "paid" ? <IntentRowActions id={r.id} /> : <span className="text-xs text-muted-foreground">—</span>}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={10} className="p-6 text-center text-sm text-muted-foreground">No records found.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between text-sm">
+        <div className="text-muted-foreground">Total: {total}</div>
+        <div className="flex items-center gap-2">
+          {Array.from({ length: pages }, (_, i) => i + 1).map((p) => {
+            const active = p === page;
+            const qs = new URLSearchParams({ q, status, method, page: String(p) }).toString();
+            return (
+              <Link
+                key={p}
+                href={`/admin/billing?${qs}`}
+                className={`px-2 py-1 rounded border ${active ? "bg-primary text-primary-foreground" : "bg-background"}`}
+              >
+                {p}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/api/admin/checkout-intents/[id]/mark/route.ts
+++ b/src/app/api/admin/checkout-intents/[id]/mark/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/admin";
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const gate = await requireAdmin();
+  if (!gate.ok) return NextResponse.json({ error: gate.reason }, { status: 403 });
+
+  const id = params.id;
+  const { status, note } = await req.json();
+  if (!["paid", "failed", "cancelled"].includes(status)) {
+    return NextResponse.json({ error: "invalid-status" }, { status: 400 });
+  }
+
+  await prisma.checkoutIntent.update({
+    where: { id },
+    data: { status },
+  });
+
+  if (note) {
+    // Optionally write an audit note if you have an AuditLog; for now we just noop.
+    // You can add an AuditLog model later and insert here.
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/checkout-intents/route.ts
+++ b/src/app/api/admin/checkout-intents/route.ts
@@ -1,0 +1,41 @@
+// List endpoint (optional; page queries DB directly, but this is handy for clients)
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/admin";
+
+export async function GET(req: Request) {
+  const gate = await requireAdmin();
+  if (!gate.ok) return NextResponse.json({ error: gate.reason }, { status: 403 });
+
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q")?.trim();
+  const status = searchParams.get("status") || undefined;
+  const method = searchParams.get("method") || undefined;
+  const page = Math.max(1, Number(searchParams.get("page") || "1"));
+  const pageSize = Math.min(100, Math.max(10, Number(searchParams.get("size") || "20")));
+
+  const where: any = {};
+  if (status && status !== "all") where.status = status;
+  if (method && method !== "all") where.paymentMethod = method;
+  if (q) {
+    where.OR = [
+      { id: { contains: q } },
+      { externalRef: { contains: q } },
+      { plan: { contains: q } },
+      { user: { email: { contains: q } } },
+    ];
+  }
+
+  const [rows, total] = await Promise.all([
+    prisma.checkoutIntent.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: { user: { select: { email: true, name: true } } },
+    }),
+    prisma.checkoutIntent.count({ where }),
+  ]);
+
+  return NextResponse.json({ rows, total, page, pageSize });
+}

--- a/src/components/admin/IntentRowActions.tsx
+++ b/src/components/admin/IntentRowActions.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function IntentRowActions({ id }: { id: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [note, setNote] = useState("");
+
+  async function update(status: "paid" | "failed" | "cancelled") {
+    startTransition(async () => {
+      const res = await fetch(`/api/admin/checkout-intents/${id}/mark`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, note }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        alert(j?.error ?? "Update failed");
+        return;
+      }
+      setNote("");
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        className="rounded border px-2 py-1 text-xs bg-background w-40"
+        placeholder="note (optional)"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+      <button disabled={pending} onClick={() => update("paid")} className="text-xs px-2 py-1 rounded bg-green-600 text-white disabled:opacity-60">
+        Mark paid
+      </button>
+      <button disabled={pending} onClick={() => update("failed")} className="text-xs px-2 py-1 rounded bg-red-600 text-white disabled:opacity-60">
+        Mark failed
+      </button>
+      <button disabled={pending} onClick={() => update("cancelled")} className="text-xs px-2 py-1 rounded bg-amber-600 text-white disabled:opacity-60">
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/src/components/admin/MethodBadge.tsx
+++ b/src/components/admin/MethodBadge.tsx
@@ -1,0 +1,11 @@
+const map: Record<string, string> = {
+  paypal: "PayPal",
+  zelle: "Zelle",
+  mmg: "MMG",
+  bank: "Bank",
+};
+
+export default function MethodBadge({ method }: { method: string | null }) {
+  const label = method ? map[method] ?? method : "—";
+  return <span className="px-2 py-0.5 rounded text-xs border bg-card">{label}</span>;
+}

--- a/src/components/admin/StatusBadge.tsx
+++ b/src/components/admin/StatusBadge.tsx
@@ -1,0 +1,13 @@
+export default function StatusBadge({ status }: { status: string }) {
+  const cls =
+    status === "paid"
+      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+      : status === "failed"
+      ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300"
+      : status === "cancelled"
+      ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+      : status === "processing"
+      ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+      : "bg-muted text-muted-foreground";
+  return <span className={`px-2 py-0.5 rounded text-xs capitalize ${cls}`}>{status}</span>;
+}

--- a/src/components/nav/Sidebar.tsx
+++ b/src/components/nav/Sidebar.tsx
@@ -5,72 +5,83 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import {
   LayoutDashboard, Users, Package, FileText, CreditCard,
-  Building2, Receipt, Banknote, Table2, ChartBar, Settings
+  Building2, Receipt, Banknote, Table2, ChartBar, Settings, ShieldCheck
 } from "lucide-react";
+import { useEffect, useState } from "react";
 
-const sections = [
-  {
-    label: "Overview",
-    items: [
-      { href: "/dashboard", icon: LayoutDashboard, label: "Dashboard" },
-    ],
-  },
-  {
-    label: "Sales",
-    items: [
-      { href: "/customers", icon: Users, label: "Customers" },
-      { href: "/items", icon: Package, label: "Items" },
-      { href: "/estimates", icon: FileText, label: "Estimates" },
-      { href: "/invoices", icon: Receipt, label: "Invoices" },
-      { href: "/payments", icon: CreditCard, label: "Payments" },
-    ],
-  },
-  {
-    label: "Purchases",
-    items: [
-      { href: "/vendors", icon: Building2, label: "Vendors" },
-      { href: "/bills", icon: Receipt, label: "Bills" },
-    ],
-  },
-  {
-    label: "Banking",
-    items: [
-      { href: "/banking/imports", icon: Banknote, label: "Import & Reconcile" },
-    ],
-  },
-  {
-    label: "Reports",
-    items: [
-      { href: "/reports/vat", icon: Table2, label: "VAT Summary" },
-      { href: "/reports/trial-balance", icon: ChartBar, label: "Trial Balance" },
-      { href: "/reports/profit-loss", icon: ChartBar, label: "Profit & Loss" },
-    ],
-  },
-  {
-    label: "Settings",
-    items: [
-      { href: "/settings/profile", icon: Settings, label: "Profile" },
-      { href: "/settings/organization", icon: Settings, label: "Organization" },
-      { href: "/settings/branding", icon: Settings, label: "Branding" },
-    ],
-  },
-];
+const adminSection = {
+  label: "Admin",
+  items: [{ href: "/admin/billing", icon: ShieldCheck, label: "Billing" }],
+};
 
 export default function Sidebar() {
   const pathname = usePathname();
+  const [showAdmin, setShowAdmin] = useState(false);
+
+  useEffect(() => {
+    // Non-sensitive UI hint: if ADMIN_EMAILS is set at build time, show the link.
+    if (process.env.NEXT_PUBLIC_HAS_ADMIN === "1") setShowAdmin(true);
+  }, []);
+
+  const sections = [
+    {
+      label: "Overview",
+      items: [{ href: "/dashboard", icon: LayoutDashboard, label: "Dashboard" }],
+    },
+    {
+      label: "Sales",
+      items: [
+        { href: "/customers", icon: Users, label: "Customers" },
+        { href: "/items", icon: Package, label: "Items" },
+        { href: "/estimates", icon: FileText, label: "Estimates" },
+        { href: "/invoices", icon: Receipt, label: "Invoices" },
+        { href: "/payments", icon: CreditCard, label: "Payments" },
+      ],
+    },
+    {
+      label: "Purchases",
+      items: [
+        { href: "/vendors", icon: Building2, label: "Vendors" },
+        { href: "/bills", icon: Receipt, label: "Bills" },
+      ],
+    },
+    {
+      label: "Banking",
+      items: [{ href: "/banking/imports", icon: Banknote, label: "Import & Reconcile" }],
+    },
+    {
+      label: "Reports",
+      items: [
+        { href: "/reports/vat", icon: Table2, label: "VAT Summary" },
+        { href: "/reports/trial-balance", icon: ChartBar, label: "Trial Balance" },
+        { href: "/reports/profit-loss", icon: ChartBar, label: "Profit & Loss" },
+      ],
+    },
+    {
+      label: "Settings",
+      items: [
+        { href: "/settings/profile", icon: Settings, label: "Profile" },
+        { href: "/settings/organization", icon: Settings, label: "Organization" },
+        { href: "/settings/branding", icon: Settings, label: "Branding" },
+      ],
+    },
+  ];
+
+  if (showAdmin) sections.push(adminSection as any);
+
   return (
     <aside className="w-64 shrink-0 border-r bg-background/60 backdrop-blur">
       <div className="p-4">
         <div className="text-xl font-semibold">heroBooks</div>
       </div>
       <nav className="px-2 pb-6 space-y-6">
-        {sections.map((s) => (
+        {sections.map((s: any) => (
           <div key={s.label}>
             <div className="px-2 text-[11px] uppercase tracking-wider text-muted-foreground mb-2">
               {s.label}
             </div>
             <ul className="space-y-1">
-              {s.items.map((item) => {
+              {s.items.map((item: any) => {
                 const active = pathname === item.href || pathname?.startsWith(item.href + "/");
                 const Icon = item.icon;
                 return (
@@ -79,9 +90,7 @@ export default function Sidebar() {
                       href={item.href}
                       className={cn(
                         "flex items-center gap-2 rounded-md px-3 py-2 text-sm",
-                        active
-                          ? "bg-primary/10 text-primary"
-                          : "hover:bg-muted text-foreground"
+                        active ? "bg-primary/10 text-primary" : "hover:bg-muted text-foreground"
                       )}
                     >
                       <Icon className="h-4 w-4" />

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,14 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "./auth";
+
+export async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) return { ok: false as const, reason: "unauthorized" };
+  const allow = (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  if (!allow.length) return { ok: false as const, reason: "no-admin-config" };
+  const is = allow.includes(session.user.email.toLowerCase());
+  return { ok: is as const, user: session.user, reason: is ? null : "forbidden" as const };
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,1 @@
+export { authOptions } from "./authOptions";


### PR DESCRIPTION
## Summary
- gate admin pages with requireAdmin using ADMIN_EMAILS env var
- add /admin/billing UI to search and resolve checkout intents
- expose optional sidebar link when NEXT_PUBLIC_HAS_ADMIN=1

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6771a59148329b379fa4511589067