### PR TITLE
feat: add audit logs and subscription scaffolding

### DIFF
--- a/docs/ADMIN-BILLING.md
+++ b/docs/ADMIN-BILLING.md
@@ -1,0 +1,17 @@
+# Admin Billing – How activation works
+
+- A `CheckoutIntent` transitions to **paid** via:
+  - PayPal capture success (`/api/paypal/capture`)
+  - MMG webhook callback (`/api/webhooks/mmg`)
+  - Manual admin action (`/api/admin/checkout-intents/:id/mark` with status=paid)
+
+- On **paid**, we call `activateSubscriptionFromIntent(intentId)`:
+  - If the paying user is member of exactly **one** org → create `OrgSubscription` with that `orgId` and `status="active"`.
+  - If the user has **multiple** orgs → create a subscription with `status="pending_assignment"` and **no `orgId`**. An admin can later assign it (future UI).
+
+- Every transition writes an `AuditLog` record so there’s a durable trail.
+
+> Future improvements:
+> - Add an Admin “Assign to Org” action for `pending_assignment` subscriptions.
+> - Add renewal cron that extends `currentPeriodEnd` monthly while payment is valid.
+> - Email real receipts via your SMTP (replace the console log in `email.ts`).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "imapflow": "^1.0.0",
     "lucide-react": "^0.542.0",
     "mailparser": "^3.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       imapflow:
         specifier: ^1.0.0
         version: 1.0.195
@@ -1403,6 +1406,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -4822,6 +4828,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns@4.1.0: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -5046,8 +5054,8 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5066,7 +5074,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -5077,22 +5085,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.41.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5103,7 +5111,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.41.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/prisma/migrations/20250917000000_rev2_audit_and_subscriptions/migration.sql
+++ b/prisma/migrations/20250917000000_rev2_audit_and_subscriptions/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "actorId" TEXT,
+    "actorEmail" TEXT,
+    "action" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "metadata" JSONB,
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrgSubscription" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT,
+    "plan" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "currentPeriodStart" TIMESTAMP(3) NOT NULL,
+    "currentPeriodEnd" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "checkoutIntentId" TEXT,
+    CONSTRAINT "OrgSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "OrgSubscription" ADD CONSTRAINT "OrgSubscription_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrgSubscription" ADD CONSTRAINT "OrgSubscription_checkoutIntentId_fkey" FOREIGN KEY ("checkoutIntentId") REFERENCES "CheckoutIntent"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,18 +16,19 @@ enum Role {
 }
 
 model User {
-  id            String          @id @default(cuid())
-  name          String?
-  email         String?         @unique
-  emailVerified DateTime?
-  image         String?
-  passwordHash  String?
-  accounts      Account[]
-  sessions      Session[]
-  memberships   UserOrg[]
-  preference    UserPreference?
-  createdAt     DateTime        @default(now())
-  updatedAt     DateTime        @default(now()) @updatedAt
+  id             String           @id @default(cuid())
+  name           String?
+  email          String?          @unique
+  emailVerified  DateTime?
+  image          String?
+  passwordHash   String?
+  accounts       Account[]
+  sessions       Session[]
+  memberships    UserOrg[]
+  preference     UserPreference?
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @default(now()) @updatedAt
+  CheckoutIntent CheckoutIntent[]
 }
 
 model Org {
@@ -47,6 +48,7 @@ model Org {
   bankTransactions BankTransaction[]
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
+  OrgSubscription  OrgSubscription[]
 }
 
 model OrgSettings {
@@ -333,6 +335,31 @@ model UserPreference {
   updatedAt DateTime @updatedAt
 }
 
+model AuditLog {
+  id         String   @id @default(cuid())
+  createdAt  DateTime @default(now())
+  actorId    String?
+  actorEmail String?
+  action     String
+  targetType String
+  targetId   String
+  metadata   Json?
+}
+
+model OrgSubscription {
+  id                 String          @id @default(cuid())
+  org                Org?            @relation(fields: [orgId], references: [id], onDelete: SetNull)
+  orgId              String?
+  plan               String
+  status             String          @default("active") // active|cancelled|expired|pending_assignment
+  currentPeriodStart DateTime
+  currentPeriodEnd   DateTime
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+  checkoutIntent     CheckoutIntent? @relation(fields: [checkoutIntentId], references: [id], onDelete: SetNull)
+  checkoutIntentId   String?
+}
+
 model CheckoutIntent {
   id            String   @id @default(cuid())
   user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -343,8 +370,10 @@ model CheckoutIntent {
   discount      Int      @default(0)
   promoCode     String?
   status        String   @default("created") // created|processing|paid|failed|cancelled
-  paymentMethod String?  // "paypal" | "zelle" | "mmg" | "bank"
-  externalRef   String?  // PSP order/transaction reference
+  paymentMethod String? // "paypal" | "zelle" | "mmg" | "bank"
+  externalRef   String? // PSP order/transaction reference
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
+
+  subscription OrgSubscription[]
 }

--- a/src/app/(app)/admin/billing/page.tsx
+++ b/src/app/(app)/admin/billing/page.tsx
@@ -1,0 +1,71 @@
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/admin";
+import StatusBadge from "@/components/admin/StatusBadge";
+import MethodBadge from "@/components/admin/MethodBadge";
+import IntentRowActions from "@/components/admin/IntentRowActions";
+
+export default async function AdminBillingPage() {
+  const gate = await requireAdmin();
+  if (!gate.ok) {
+    return <div className="p-4 text-sm">Access denied</div>;
+  }
+
+  const rows = await prisma.checkoutIntent.findMany({
+    include: { user: { select: { name: true, email: true } } },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="p-4">
+      <div className="rounded-xl border overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="text-left p-2">Created</th>
+              <th className="text-left p-2">Intent</th>
+              <th className="text-left p-2">User</th>
+              <th className="text-left p-2">Plan</th>
+              <th className="text-left p-2">Amount (GYD)</th>
+              <th className="text-left p-2">Discount</th>
+              <th className="text-left p-2">Method</th>
+              <th className="text-left p-2">External Ref</th>
+              <th className="text-left p-2">Status</th>
+              <th className="text-left p-2">Sub?</th>
+              <th className="text-left p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="p-2 whitespace-nowrap">{new Date(r.createdAt).toLocaleString()}</td>
+                <td className="p-2 font-mono text-xs">{r.id}</td>
+                <td className="p-2">
+                  <div className="flex flex-col">
+                    <span>{r.user?.name ?? "—"}</span>
+                    <span className="text-xs text-muted-foreground">{r.user?.email ?? "—"}</span>
+                  </div>
+                </td>
+                <td className="p-2 capitalize">{r.plan}</td>
+                <td className="p-2">GYD ${r.amount.toLocaleString()}</td>
+                <td className="p-2">GYD ${r.discount.toLocaleString()}</td>
+                <td className="p-2"><MethodBadge method={r.paymentMethod ?? null} /></td>
+                <td className="p-2 font-mono text-xs">{r.externalRef ?? "—"}</td>
+                <td className="p-2"><StatusBadge status={r.status} /></td>
+                <td className="p-2">
+                  {r.status === "paid" ? (
+                    <span className="text-xs">Created</span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">—</span>
+                  )}
+                </td>
+                <td className="p-2">
+                  {r.status !== "paid" ? <IntentRowActions id={r.id} /> : <span className="text-xs text-muted-foreground">—</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/checkout-intents/[id]/mark/route.ts
+++ b/src/app/api/admin/checkout-intents/[id]/mark/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/admin";
+import { activateSubscriptionFromIntent } from "@/lib/subscriptions/activate";
+import { sendReceiptEmail } from "@/lib/subscriptions/email";
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const gate = await requireAdmin();
+  if (!gate.ok) return NextResponse.json({ error: gate.reason }, { status: 403 });
+
+  const id = params.id;
+  const { status, note } = await req.json();
+  if (!["paid", "failed", "cancelled"].includes(status)) {
+    return NextResponse.json({ error: "invalid-status" }, { status: 400 });
+  }
+
+  const intentBefore = await prisma.checkoutIntent.findUnique({ where: { id } });
+  if (!intentBefore) return NextResponse.json({ error: "not-found" }, { status: 404 });
+
+  await prisma.checkoutIntent.update({
+    where: { id },
+    data: { status },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      actorId: (gate as any)?.user?.id ?? null,
+      actorEmail: (gate as any)?.user?.email ?? null,
+      action: "checkout.intent.updated",
+      targetType: "CheckoutIntent",
+      targetId: id,
+      metadata: { from: intentBefore.status, to: status, note: note ?? null },
+    },
+  });
+
+  if (status === "paid") {
+    await activateSubscriptionFromIntent(id);
+    await sendReceiptEmail(id);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/paypal/capture/route.ts
+++ b/src/app/api/paypal/capture/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { activateSubscriptionFromIntent } from "@/lib/subscriptions/activate";
+import { sendReceiptEmail } from "@/lib/subscriptions/email";
 
 const PAYPAL_BASE =
   process.env.PAYPAL_ENV === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
@@ -34,10 +36,33 @@ export async function GET(req: Request) {
       where: { id: intentId },
       data: { status: "paid", externalRef: token },
     });
+    await prisma.auditLog.create({
+      data: {
+        actorId: null,
+        actorEmail: null,
+        action: "paypal.capture.succeeded",
+        targetType: "CheckoutIntent",
+        targetId: intentId,
+        metadata: capJson ?? {},
+      },
+    });
+
+    await activateSubscriptionFromIntent(intentId);
+    await sendReceiptEmail(intentId);
   } else {
     await prisma.checkoutIntent.update({
       where: { id: intentId },
       data: { status: "failed" },
+    });
+    await prisma.auditLog.create({
+      data: {
+        actorId: null,
+        actorEmail: null,
+        action: "paypal.capture.failed",
+        targetType: "CheckoutIntent",
+        targetId: intentId,
+        metadata: capJson ?? {},
+      },
     });
   }
 

--- a/src/app/api/webhooks/mmg/route.ts
+++ b/src/app/api/webhooks/mmg/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { mmgProvider } from "@/lib/payments/mmg";
+import { activateSubscriptionFromIntent } from "@/lib/subscriptions/activate";
+import { sendReceiptEmail } from "@/lib/subscriptions/email";
 
 export const dynamic = "force-dynamic";
 
@@ -14,8 +16,24 @@ export async function POST(req: Request) {
 
   await prisma.checkoutIntent.update({
     where: { id: intentId },
-    data: { status: status === "paid" ? "paid" : status, externalRef: externalRef ?? undefined },
+    data: { status: status === "paid" ? "paid" : status!, externalRef: externalRef ?? undefined },
   });
+
+  await prisma.auditLog.create({
+    data: {
+      actorId: null,
+      actorEmail: null,
+      action: "mmg.webhook",
+      targetType: "CheckoutIntent",
+      targetId: intentId,
+      metadata: parsed,
+    },
+  });
+
+  if (status === "paid") {
+    await activateSubscriptionFromIntent(intentId);
+    await sendReceiptEmail(intentId);
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/src/components/admin/IntentRowActions.tsx
+++ b/src/components/admin/IntentRowActions.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function IntentRowActions({ id }: { id: string }) {
+  const [loading, setLoading] = useState(false);
+
+  async function markPaid() {
+    setLoading(true);
+    try {
+      await fetch(`/api/admin/checkout-intents/${id}/mark`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "paid" }),
+      });
+      location.reload();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Button onClick={markPaid} disabled={loading} size="sm">
+      Mark paid
+    </Button>
+  );
+}

--- a/src/components/admin/MethodBadge.tsx
+++ b/src/components/admin/MethodBadge.tsx
@@ -1,0 +1,4 @@
+export default function MethodBadge({ method }: { method: string | null }) {
+  if (!method) return <span className="text-xs text-muted-foreground">—</span>;
+  return <span className="inline-block text-xs capitalize">{method}</span>;
+}

--- a/src/components/admin/StatusBadge.tsx
+++ b/src/components/admin/StatusBadge.tsx
@@ -1,0 +1,3 @@
+export default function StatusBadge({ status }: { status: string }) {
+  return <span className="inline-block rounded bg-accent px-2 py-0.5 text-xs capitalize">{status}</span>;
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,19 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
+import { prisma } from "@/lib/prisma";
+
+export async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return { ok: false, reason: "unauthorized" } as const;
+  }
+  const userId = (session.user as any).id as string;
+  const membership = await prisma.userOrg.findFirst({
+    where: { userId, role: { in: ["OWNER", "ADMIN"] } },
+    select: { user: { select: { id: true, email: true } } },
+  });
+  if (!membership) {
+    return { ok: false, reason: "forbidden" } as const;
+  }
+  return { ok: true, user: membership.user } as const;
+}

--- a/src/lib/subscriptions/activate.ts
+++ b/src/lib/subscriptions/activate.ts
@@ -1,0 +1,75 @@
+import { prisma } from "@/lib/prisma";
+import { addMonths, startOfDay } from "date-fns";
+
+/**
+ * Idempotent activation:
+ * - Ensures CheckoutIntent is 'paid' before activating
+ * - If user has exactly one org → attach subscription to that org
+ * - Else create subscription with status 'pending_assignment' (manual follow-up)
+ * Returns the subscription id (or existing one if already present).
+ */
+export async function activateSubscriptionFromIntent(intentId: string) {
+  const intent = await prisma.checkoutIntent.findUnique({
+    where: { id: intentId },
+    include: {
+      user: {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          memberships: { select: { orgId: true } },
+        },
+      },
+    },
+  });
+  if (!intent) throw new Error("Intent not found");
+
+  if (intent.status !== "paid") {
+    return null;
+  }
+
+  const existing = await prisma.orgSubscription.findFirst({
+    where: { checkoutIntentId: intent.id },
+    select: { id: true },
+  });
+  if (existing) return existing.id;
+
+  const orgIds = (intent.user as any)?.memberships?.map((uo: any) => uo.orgId) ?? [];
+  const orgId = orgIds.length === 1 ? orgIds[0] : null;
+  const status = orgId ? "active" : "pending_assignment";
+
+  const now = new Date();
+  const periodStart = startOfDay(now);
+  const periodEnd = startOfDay(addMonths(now, 1));
+
+  const sub = await prisma.orgSubscription.create({
+    data: {
+      orgId,
+      plan: intent.plan,
+      status,
+      currentPeriodStart: periodStart,
+      currentPeriodEnd: periodEnd,
+      checkoutIntentId: intent.id,
+    },
+    select: { id: true },
+  });
+
+  await prisma.auditLog.create({
+    data: {
+      actorId: null,
+      actorEmail: null,
+      action: "subscription.activated",
+      targetType: "OrgSubscription",
+      targetId: sub.id,
+      metadata: {
+        fromIntent: intent.id,
+        plan: intent.plan,
+        amountGYD: intent.amount,
+        paymentMethod: intent.paymentMethod,
+        orgAttached: orgId ? true : false,
+      },
+    },
+  });
+
+  return sub.id;
+}

--- a/src/lib/subscriptions/email.ts
+++ b/src/lib/subscriptions/email.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@/lib/prisma";
+
+export async function sendReceiptEmail(intentId: string) {
+  try {
+    const intent = await prisma.checkoutIntent.findUnique({
+      where: { id: intentId },
+      include: { user: { select: { email: true, name: true } } },
+    });
+    if (!intent?.user?.email) return;
+
+    console.log("[mailer] Sending receipt", {
+      to: intent.user.email,
+      subject: `Receipt — heroBooks ${intent.plan} plan`,
+      body: `We received your payment of GYD $${intent.amount.toLocaleString()}. Thanks! Reference: ${intent.externalRef ?? intent.id}`,
+    });
+  } catch {
+    // swallow
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold audit logging and organization subscriptions in Prisma
- centralize subscription activation & receipt emails
- log status changes from PayPal, MMG webhook, and admin approval

## Testing
- `pnpm dlx prisma migrate dev -n "rev2_audit_and_subscriptions"` (fails: Can't reach database server at `localhost:5432`)
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b678f225dc8329ba42a3fcb59ca65e