### PR TITLE
fix: scope admin billing by organization

### DIFF
--- a/src/app/(app)/admin/billing/page.tsx
+++ b/src/app/(app)/admin/billing/page.tsx
@@ -11,6 +11,9 @@ export default async function AdminBillingPage() {
   }
 
   const rows = await prisma.checkoutIntent.findMany({
+    where: {
+      user: { memberships: { some: { orgId: gate.orgId } } },
+    },
     include: { user: { select: { name: true, email: true } } },
     orderBy: { createdAt: "desc" },
   });

--- a/src/app/api/admin/checkout-intents/[id]/mark/route.ts
+++ b/src/app/api/admin/checkout-intents/[id]/mark/route.ts
@@ -14,7 +14,12 @@ export async function POST(req: Request, { params }: { params: { id: string } })
     return NextResponse.json({ error: "invalid-status" }, { status: 400 });
   }
 
-  const intentBefore = await prisma.checkoutIntent.findUnique({ where: { id } });
+  const intentBefore = await prisma.checkoutIntent.findFirst({
+    where: {
+      id,
+      user: { memberships: { some: { orgId: gate.orgId } } },
+    },
+  });
   if (!intentBefore) return NextResponse.json({ error: "not-found" }, { status: 404 });
 
   await prisma.checkoutIntent.update({

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -10,10 +10,10 @@ export async function requireAdmin() {
   const userId = (session.user as any).id as string;
   const membership = await prisma.userOrg.findFirst({
     where: { userId, role: { in: ["OWNER", "ADMIN"] } },
-    select: { user: { select: { id: true, email: true } } },
+    select: { orgId: true, user: { select: { id: true, email: true } } },
   });
   if (!membership) {
     return { ok: false, reason: "forbidden" } as const;
   }
-  return { ok: true, user: membership.user } as const;
+  return { ok: true, user: membership.user, orgId: membership.orgId } as const;
 }


### PR DESCRIPTION
## Summary
- return organization ID from `requireAdmin`
- restrict admin billing listings and updates to user's organization

## Testing
- `pnpm lint`
- `pnpm dlx prisma migrate dev -n "rev2_audit_and_subscriptions"` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa0d1b148329925217f5ce994bd2