### PR TITLE
feat: verify MMG webhook signature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ MMG_BASE_URL=https://uat-developer.mmg.gy
 MMG_MERCHANT_ID=
 MMG_API_KEY=
 MMG_CHECKOUT_PATH=/api/checkout
+# Secret used to verify the X-MMG-Signature header on incoming webhooks
 MMG_WEBHOOK_SECRET=
 
 # Bank transfer (manual)

--- a/src/lib/payments/mmg.ts
+++ b/src/lib/payments/mmg.ts
@@ -1,4 +1,5 @@
 import { PaymentProvider, CreateCheckoutInput, CreateCheckoutResult } from "./types";
+import { createHmac, timingSafeEqual } from "crypto";
 
 // MMG (QR / hosted) — stub; adjust with real docs
 const MMG_BASE = process.env.MMG_BASE_URL ?? "https://uat-developer.mmg.gy";
@@ -36,6 +37,19 @@ export const mmgProvider: PaymentProvider = {
   },
   async verifyAndParseWebhook(req: Request, rawBody: string) {
     try {
+      const signature = req.headers.get("x-mmg-signature") ?? "";
+      const secret = process.env.MMG_WEBHOOK_SECRET ?? "";
+
+      if (!signature || !secret) return { ok: false };
+
+      const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+      const sigBuf = Buffer.from(signature, "hex");
+      const expBuf = Buffer.from(expected, "hex");
+
+      if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+        return { ok: false };
+      }
+
       const body = JSON.parse(rawBody || "{}");
       const statusMap: Record<string, "paid" | "failed" | "cancelled" | "pending"> = {
         SUCCESS: "paid",


### PR DESCRIPTION
## Summary
- verify MMG webhooks using `X-MMG-Signature` and `MMG_WEBHOOK_SECRET`
- document MMG webhook signature header

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6fa9e63ec8329ba8bbca9fe5986b7