### PR TITLE
feat: add pricing helpers

### DIFF
--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,22 @@
+import { type Plan } from "./plans";
+
+const PLAN_PRICES: Record<Plan, number> = {
+  starter: 0,
+  business: 9900,
+  enterprise: 0,
+};
+
+export function getPlanPriceGyd(plan: Plan): number {
+  return PLAN_PRICES[plan] ?? 0;
+}
+
+export function applyPromo(amount: number, promoCode?: string) {
+  const code = (promoCode ?? "").trim().toUpperCase();
+  if (amount > 0 && code === "GYA-LAUNCH") {
+    const discountAmount = Math.round(amount * 0.5);
+    const finalAmount = amount - discountAmount;
+    return { finalAmount, discountAmount, promoApplied: code };
+  }
+  return { finalAmount: amount, discountAmount: 0, promoApplied: undefined };
+}
+


### PR DESCRIPTION
## Summary
- add pricing helper for plan cost and promo codes

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Parameter 'r' implicitly has an 'any' type in src/app/(app)/admin/billing/page.tsx:105:24)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa9db7ec8329a29ad508a0db7312