### PR TITLE
refactor admin gate typing

### DIFF
--- a/src/app/api/admin/checkout-intents/[id]/mark/route.ts
+++ b/src/app/api/admin/checkout-intents/[id]/mark/route.ts
@@ -24,8 +24,8 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   await prisma.auditLog.create({
     data: {
-      actorId: (gate as any)?.user?.id ?? null,
-      actorEmail: (gate as any)?.user?.email ?? null,
+      actorId: gate.user?.id ?? null,
+      actorEmail: gate.user?.email ?? null,
       action: "checkout.intent.updated",
       targetType: "CheckoutIntent",
       targetId: id,

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,14 +1,24 @@
 import { getServerSession } from "next-auth";
+import type { Session } from "next-auth";
 import { authOptions } from "./auth";
 
-export async function requireAdmin() {
+type AdminGate =
+  | { ok: true; user: Session["user"]; reason: null }
+  | {
+      ok: false;
+      reason: "unauthorized" | "no-admin-config" | "forbidden";
+    };
+
+export async function requireAdmin(): Promise<AdminGate> {
   const session = await getServerSession(authOptions);
-  if (!session?.user?.email) return { ok: false as const, reason: "unauthorized" };
+  if (!session?.user?.email)
+    return { ok: false, reason: "unauthorized" };
   const allow = (process.env.ADMIN_EMAILS ?? "")
     .split(",")
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
-  if (!allow.length) return { ok: false as const, reason: "no-admin-config" };
+  if (!allow.length) return { ok: false, reason: "no-admin-config" };
   const is = allow.includes(session.user.email.toLowerCase());
-  return { ok: is as const, user: session.user, reason: is ? null : "forbidden" as const };
+  if (!is) return { ok: false, reason: "forbidden" };
+  return { ok: true, user: session.user, reason: null };
 }


### PR DESCRIPTION
## Summary
- tighten requireAdmin return type and expose user when access granted
- remove `as any` from checkout intent mark route

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Module not found: Can't resolve 'date-fns')*


------
https://chatgpt.com/codex/tasks/task_e_68b76e2b16c08329a4e6cab6d1a17013