### PR TITLE
feat: report email receipt errors

### DIFF
--- a/src/lib/subscriptions/email.ts
+++ b/src/lib/subscriptions/email.ts
@@ -1,12 +1,12 @@
 import { prisma } from "@/lib/prisma";
 // If you already have a mailer util, import it here and replace the console.log.
-export async function sendReceiptEmail(intentId: string) {
+export async function sendReceiptEmail(intentId: string): Promise<boolean> {
   try {
     const intent = await prisma.checkoutIntent.findUnique({
       where: { id: intentId },
       include: { user: { select: { email: true, name: true } } },
     });
-    if (!intent?.user?.email) return;
+    if (!intent?.user?.email) return false;
 
     // Replace with your mailer implementation
     console.log("[mailer] Sending receipt", {
@@ -14,7 +14,10 @@ export async function sendReceiptEmail(intentId: string) {
       subject: `Receipt — heroBooks ${intent.plan} plan`,
       body: `We received your payment of GYD $${intent.amount.toLocaleString()}. Thanks! Reference: ${intent.externalRef ?? intent.id}`,
     });
-  } catch {
-    // swallow
+
+    return true;
+  } catch (err) {
+    console.error("[mailer] Failed to send receipt", err);
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- log failures when sending receipt emails
- return success/failure from sendReceiptEmail

## Testing
- `pnpm lint`
- `pnpm tsc -p tsconfig.json --noEmit` *(fails: cannot find module 'date-fns' and missing Prisma types)*

------
https://chatgpt.com/codex/tasks/task_e_68b771d024488329a0ae0b5c6ffeb14f