### PR TITLE
fix: avoid overriding successful PayPal captures

### DIFF
--- a/src/app/api/paypal/capture/route.ts
+++ b/src/app/api/paypal/capture/route.ts
@@ -56,10 +56,6 @@ export async function GET(req: Request) {
           metadata: capJson ?? {},
         },
       });
-
-      // Activate + receipt (idempotent)
-      await activateSubscriptionFromIntent(intentId);
-      await sendReceiptEmail(intentId);
     } else {
       await prisma.checkoutIntent.update({
         where: { id: intentId },
@@ -75,6 +71,7 @@ export async function GET(req: Request) {
           metadata: capJson ?? {},
         },
       });
+      return NextResponse.redirect(new URL(`/checkout/confirm?id=${intentId}`, url).toString());
     }
   } catch (err) {
     console.error(err);
@@ -87,6 +84,27 @@ export async function GET(req: Request) {
         actorId: null,
         actorEmail: null,
         action: "paypal.capture.failed",
+        targetType: "CheckoutIntent",
+        targetId: intentId,
+        metadata: {
+          error: err instanceof Error ? err.message : String(err),
+        },
+      },
+    });
+    return NextResponse.redirect(new URL(`/checkout/confirm?id=${intentId}`, url).toString());
+  }
+
+  try {
+    // Activate + receipt (idempotent)
+    await activateSubscriptionFromIntent(intentId);
+    await sendReceiptEmail(intentId);
+  } catch (err) {
+    console.error(err);
+    await prisma.auditLog.create({
+      data: {
+        actorId: null,
+        actorEmail: null,
+        action: "paypal.postprocess.failed",
         targetType: "CheckoutIntent",
         targetId: intentId,
         metadata: {


### PR DESCRIPTION
## Summary
- isolate PayPal API calls so post-processing failures don't mark captures as failed
- log post-capture issues separately without changing checkout intent status

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7737d9dc4832991f1749679d2312d