### PR TITLE
fix: scope checkout intents by organization

### DIFF
--- a/prisma/migrations/20250921000000_scope_checkout_intent_org/migration.sql
+++ b/prisma/migrations/20250921000000_scope_checkout_intent_org/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "CheckoutIntent" ADD COLUMN "orgId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "CheckoutIntent" ADD CONSTRAINT "CheckoutIntent_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "CheckoutIntent_orgId_idx" ON "CheckoutIntent"("orgId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Org {
   estimates        Estimate[]
   bankTransactions BankTransaction[]
   subscriptions    OrgSubscription[]
+  checkoutIntents  CheckoutIntent[]
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
 }
@@ -337,6 +338,8 @@ model UserPreference {
 
 model CheckoutIntent {
   id            String   @id @default(cuid())
+  org           Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
   user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId        String
   plan          String
@@ -352,6 +355,8 @@ model CheckoutIntent {
 
   // link to created subscriptions
   subscription  OrgSubscription[]
+
+  @@index([orgId])
 }
 
 model AuditLog {

--- a/src/app/(app)/admin/billing/page.tsx
+++ b/src/app/(app)/admin/billing/page.tsx
@@ -26,7 +26,7 @@ export default async function AdminBillingPage({ searchParams }: { searchParams:
   const page = Math.max(1, Number(searchParams.page ?? "1"));
   const pageSize = 20;
 
-  const where: any = {};
+  const where: any = { orgId: gate.orgId };
   if (status !== "all") where.status = status;
   if (method !== "all") where.paymentMethod = method;
   if (q) {

--- a/src/app/api/admin/checkout-intents/[id]/mark/route.ts
+++ b/src/app/api/admin/checkout-intents/[id]/mark/route.ts
@@ -14,7 +14,9 @@ export async function POST(req: Request, { params }: { params: { id: string } })
     return NextResponse.json({ error: "invalid-status" }, { status: 400 });
   }
 
-  const intentBefore = await prisma.checkoutIntent.findUnique({ where: { id } });
+  const intentBefore = await prisma.checkoutIntent.findFirst({
+    where: { id, orgId: gate.orgId },
+  });
   if (!intentBefore) return NextResponse.json({ error: "not-found" }, { status: 404 });
 
   await prisma.checkoutIntent.update({

--- a/src/app/api/admin/checkout-intents/route.ts
+++ b/src/app/api/admin/checkout-intents/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: Request) {
   const page = Math.max(1, Number(searchParams.get("page") || "1"));
   const pageSize = Math.min(100, Math.max(10, Number(searchParams.get("size") || "20")));
 
-  const where: any = {};
+  const where: any = { orgId: gate.orgId };
   if (status && status !== "all") where.status = status;
   if (method && method !== "all") where.paymentMethod = method;
   if (q) {

--- a/src/app/api/subscribe/checkout/route.ts
+++ b/src/app/api/subscribe/checkout/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { normalizePlan, type Plan } from "@/lib/plans";
 import { getPlanPriceGyd, applyPromo } from "@/lib/pricing";
 import { getProviderOrThrow } from "@/lib/payments";
+import { getActiveOrgId } from "@/lib/tenant";
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
@@ -18,9 +19,12 @@ export async function POST(req: Request) {
   const baseAmount = getPlanPriceGyd(plan);
   const { finalAmount, discountAmount, promoApplied } = applyPromo(baseAmount, promoCode);
 
+  const orgId = await getActiveOrgId();
+
   const intent = await prisma.checkoutIntent.create({
     data: {
       userId: session.user.id,
+      orgId,
       plan,
       amount: finalAmount,
       discount: discountAmount,

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,24 +1,22 @@
 import { getServerSession } from "next-auth";
 import type { Session } from "next-auth";
 import { authOptions } from "./auth";
+import { prisma } from "./prisma";
 
-type AdminGate =
-  | { ok: true; user: Session["user"]; reason: null }
-  | {
-      ok: false;
-      reason: "unauthorized" | "no-admin-config" | "forbidden";
-    };
+export type AdminGate =
+  | { ok: true; user: Session["user"]; orgId: string; reason: null }
+  | { ok: false; reason: "unauthorized" | "forbidden" };
 
 export async function requireAdmin(): Promise<AdminGate> {
   const session = await getServerSession(authOptions);
-  if (!session?.user?.email)
-    return { ok: false, reason: "unauthorized" };
-  const allow = (process.env.ADMIN_EMAILS ?? "")
-    .split(",")
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  if (!allow.length) return { ok: false, reason: "no-admin-config" };
-  const is = allow.includes(session.user.email.toLowerCase());
-  if (!is) return { ok: false, reason: "forbidden" };
-  return { ok: true, user: session.user, reason: null };
+  if (!session?.user?.id) return { ok: false, reason: "unauthorized" };
+
+  const userId = (session.user as any).id as string;
+  const membership = await prisma.userOrg.findFirst({
+    where: { userId, role: { in: ["OWNER", "ADMIN"] } },
+    select: { orgId: true, user: { select: { id: true, email: true } } },
+  });
+  if (!membership) return { ok: false, reason: "forbidden" };
+
+  return { ok: true, user: membership.user, orgId: membership.orgId, reason: null };
 }

--- a/src/lib/subscriptions/activate.ts
+++ b/src/lib/subscriptions/activate.ts
@@ -17,7 +17,6 @@ export async function activateSubscriptionFromIntent(intentId: string) {
           id: true,
           email: true,
           name: true,
-          memberships: { select: { orgId: true } },
         },
       },
     },
@@ -37,10 +36,8 @@ export async function activateSubscriptionFromIntent(intentId: string) {
   });
   if (existing) return existing.id;
 
-  // Determine orgId (single membership → auto; else pending assignment)
-  const orgIds: string[] = intent.user.memberships?.map((m: { orgId: string }) => m.orgId) ?? [];
-  const orgId = orgIds.length === 1 ? orgIds[0] : null;
-  const status = orgId ? "active" : "pending_assignment";
+  const orgId = intent.orgId;
+  const status = "active";
 
   // Compute 1-month period (simple monthly plan; adjust for annual later)
   const now = new Date();
@@ -72,7 +69,7 @@ export async function activateSubscriptionFromIntent(intentId: string) {
         plan: intent.plan,
         amountGYD: intent.amount,
         paymentMethod: intent.paymentMethod,
-        orgAttached: orgId ? true : false,
+        orgAttached: true,
       },
     },
   });


### PR DESCRIPTION
## Summary
- tie checkout intents to their organization
- restrict admin billing and intent updates to the admin's org
- store active org when creating intents and use it during subscription activation

## Testing
- `pnpm lint`
- `pnpm dlx prisma migrate dev -n "scope_checkout_intent_org"` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b8173626cc8329b38e272c4856778a