### PR TITLE
fix: prevent duplicate subscriptions

### DIFF
--- a/prisma/migrations/20250924000000_add_unique_checkout_intent/migration.sql
+++ b/prisma/migrations/20250924000000_add_unique_checkout_intent/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "OrgSubscription" ADD CONSTRAINT "OrgSubscription_checkoutIntentId_key" UNIQUE ("checkoutIntentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -376,5 +376,5 @@ model OrgSubscription {
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
   checkoutIntent      CheckoutIntent? @relation(fields: [checkoutIntentId], references: [id], onDelete: SetNull)
-  checkoutIntentId    String?
+  checkoutIntentId    String? @unique
 }


### PR DESCRIPTION
## Summary
- select user memberships using correct relation
- ensure subscription activation is idempotent via unique checkoutIntentId
- add migration to enforce uniqueness

## Testing
- `pnpm lint`
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" pnpm dlx prisma migrate dev --name "add_unique_checkout_intent"` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68b81777e3048329acea9e7615b206dd