### PR TITLE
Use Prisma for dashboard metrics

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,28 +1,6 @@
 import KpiCard from "@/components/dashboard/KpiCard";
 import { AgingList } from "@/components/dashboard/AgingList";
-// Placeholder server "queries"
-async function getDashboardData() {
-  // TODO: replace with real Prisma queries using getActiveOrgId()
-  return {
-    arTotal: 15230,
-    apTotal: 9680,
-    vatDue: 2240,
-    arAging: [
-      { label: "Current", amount: 8200 },
-      { label: "1–30d", amount: 4200 },
-      { label: "31–60d", amount: 630 },
-      { label: "61–90d", amount: 200 },
-      { label: "90d+", amount: 0 },
-    ],
-    apAging: [
-      { label: "Current", amount: 6000 },
-      { label: "1–30d", amount: 2500 },
-      { label: "31–60d", amount: 900 },
-      { label: "61–90d", amount: 280 },
-      { label: "90d+", amount: 0 },
-    ],
-  };
-}
+import { getDashboardData } from "@/lib/dashboard";
 
 export default async function DashboardPage() {
   const data = await getDashboardData();

--- a/src/lib/__tests__/dashboard.test.ts
+++ b/src/lib/__tests__/dashboard.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getDashboardDataForOrg } from "../dashboard";
+import { prisma } from "@/lib/prisma";
+
+const DAY = 1000 * 60 * 60 * 24;
+
+test("aggregates dashboard metrics", async () => {
+  const originalInvoice = prisma.invoice;
+  const originalBill = prisma.bill;
+  const realNow = Date.now;
+
+  Date.now = () => new Date("2024-02-01T00:00:00Z").getTime();
+
+  (prisma as any).invoice = {
+    findMany: async () => [
+      {
+        dueDate: new Date(Date.now() - 10 * DAY),
+        issueDate: new Date(Date.now() - 31 * DAY),
+        lines: [
+          { quantity: 1, unitPrice: 100, taxCode: { rate: 0.2 } },
+        ],
+        payments: [{ amount: 20 }],
+      },
+      {
+        dueDate: new Date(Date.now() - 40 * DAY),
+        issueDate: new Date(Date.now() - 60 * DAY),
+        lines: [
+          { quantity: 2, unitPrice: 100, taxCode: null },
+        ],
+        payments: [],
+      },
+    ],
+  };
+
+  (prisma as any).bill = {
+    findMany: async () => [
+      {
+        dueDate: new Date(Date.now() - 5 * DAY),
+        billDate: new Date(Date.now() - 20 * DAY),
+        lines: [
+          { quantity: 1, unitCost: 50, taxCode: { rate: 0.1 } },
+        ],
+        bankTransactions: [],
+      },
+      {
+        dueDate: new Date(Date.now() - 75 * DAY),
+        billDate: new Date(Date.now() - 90 * DAY),
+        lines: [
+          { quantity: 1, unitCost: 100, taxCode: null },
+        ],
+        bankTransactions: [{ amount: 30 }],
+      },
+    ],
+  };
+
+  const data = await getDashboardDataForOrg("org1");
+
+  assert.equal(data.arTotal, 300);
+  assert.equal(data.apTotal, 125);
+  assert.equal(data.vatDue, 15);
+  assert.deepEqual(data.arAging.map((b) => b.amount), [0, 100, 200, 0, 0]);
+  assert.deepEqual(data.apAging.map((b) => b.amount), [0, 55, 0, 70, 0]);
+
+  (prisma as any).invoice = originalInvoice;
+  (prisma as any).bill = originalBill;
+  Date.now = realNow;
+});

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -1,0 +1,95 @@
+import { prisma } from "@/lib/prisma";
+import { getActiveOrgId } from "@/lib/tenant";
+
+export interface AgingBucket {
+  label: string;
+  amount: number;
+}
+
+export interface DashboardData {
+  arTotal: number;
+  apTotal: number;
+  vatDue: number;
+  arAging: AgingBucket[];
+  apAging: AgingBucket[];
+}
+
+const LABELS = ["Current", "1–30d", "31–60d", "61–90d", "90d+"];
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function bucketIndex(daysPastDue: number): number {
+  if (daysPastDue <= 0) return 0; // current or not yet due
+  if (daysPastDue <= 30) return 1;
+  if (daysPastDue <= 60) return 2;
+  if (daysPastDue <= 90) return 3;
+  return 4;
+}
+
+export async function getDashboardDataForOrg(orgId: string): Promise<DashboardData> {
+  const [invoices, bills] = await Promise.all([
+    prisma.invoice.findMany({
+      where: { orgId, status: { not: "paid" } },
+      include: { lines: { include: { taxCode: true } }, payments: true },
+    }),
+    prisma.bill.findMany({
+      where: { orgId },
+      include: { lines: { include: { taxCode: true } }, bankTransactions: true },
+    }),
+  ]);
+
+  const arBuckets = [0, 0, 0, 0, 0];
+  const apBuckets = [0, 0, 0, 0, 0];
+  let arTotal = 0;
+  let apTotal = 0;
+  let outputVat = 0;
+  let inputVat = 0;
+  const now = Date.now();
+
+  for (const inv of invoices) {
+    let base = 0;
+    let vat = 0;
+    for (const line of inv.lines) {
+      const lineBase = Number(line.unitPrice) * line.quantity;
+      base += lineBase;
+      if (line.taxCode) vat += lineBase * line.taxCode.rate;
+    }
+    outputVat += vat;
+    const total = base + vat;
+    const paid = inv.payments.reduce((s, p) => s + Number(p.amount), 0);
+    const outstanding = total - paid;
+    arTotal += outstanding;
+    const due = (inv.dueDate || inv.issueDate).getTime();
+    const days = Math.floor((now - due) / MS_PER_DAY);
+    arBuckets[bucketIndex(days)] += outstanding;
+  }
+
+  for (const bill of bills) {
+    let base = 0;
+    let vat = 0;
+    for (const line of bill.lines) {
+      const lineBase = Number(line.unitCost) * line.quantity;
+      base += lineBase;
+      if (line.taxCode) vat += lineBase * line.taxCode.rate;
+    }
+    inputVat += vat;
+    const total = base + vat;
+    const paid = bill.bankTransactions.reduce((s, tx) => s + Number(tx.amount), 0);
+    const outstanding = total - paid;
+    apTotal += outstanding;
+    const due = (bill.dueDate || bill.billDate).getTime();
+    const days = Math.floor((now - due) / MS_PER_DAY);
+    apBuckets[bucketIndex(days)] += outstanding;
+  }
+
+  const arAging = LABELS.map((label, i) => ({ label, amount: arBuckets[i] }));
+  const apAging = LABELS.map((label, i) => ({ label, amount: apBuckets[i] }));
+  const vatDue = outputVat - inputVat;
+
+  return { arTotal, apTotal, vatDue, arAging, apAging };
+}
+
+export async function getDashboardData(): Promise<DashboardData> {
+  const orgId = await getActiveOrgId();
+  return getDashboardDataForOrg(orgId);
+}


### PR DESCRIPTION
## Summary
- replace dashboard mock data with Prisma-driven `getDashboardData`
- add helper module aggregating AR/AP totals, VAT and aging buckets
- cover dashboard helper with unit tests

## Testing
- `pnpm lint`
- `pnpm dlx tsx src/lib/__tests__/dashboard.test.ts`
- `pnpm dlx tsx src/lib/subscriptions/__tests__/activate.test.ts` *(fails: assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e50eaff083298dbe0fb782a27906