### PR TITLE
fix: add login route

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default function LoginPage() {
+  redirect("/sign-in");
+}
+


### PR DESCRIPTION
## Summary
- redirect `/login` to existing `/sign-in` page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac2cf60883299f1569380f97cc30