### PR TITLE
Wrap marketing pages in SessionProvider

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,6 +1,6 @@
 import MarketingHeader from "@/components/marketing/MarketingHeader";
 import MarketingFooter from "@/components/marketing/MarketingFooter";
-import { ThemeProvider } from "@/components/ui/theme-provider";
+import { MarketingProviders } from "@/components/marketing/MarketingProviders";
 
 export const metadata = {
   title: "heroBooks — Guyana-first Accounting",
@@ -10,12 +10,12 @@ export const metadata = {
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <MarketingProviders>
       <div className="min-h-screen flex flex-col bg-background">
         <MarketingHeader />
         <main className="flex-1">{children}</main>
         <MarketingFooter />
       </div>
-    </ThemeProvider>
+    </MarketingProviders>
   );
 }

--- a/src/components/marketing/MarketingProviders.tsx
+++ b/src/components/marketing/MarketingProviders.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import { ThemeProvider } from "@/components/ui/theme-provider";
+
+export function MarketingProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
+    </SessionProvider>
+  );
+}

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -20,12 +20,16 @@ export const authConfig = {
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
-        if (!credentials?.email || !credentials.password) return null;
-        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
+        const { email, password } = credentials as {
+          email?: string;
+          password?: string;
+        };
+        if (!email || !password) return null;
+        const user = await prisma.user.findUnique({ where: { email } });
         if (!user || !user.passwordHash) {
           throw new Error("No user found");
         }
-        const valid = await compare(credentials.password, user.passwordHash);
+        const valid = await compare(password, user.passwordHash);
         if (!valid) {
           throw new Error("Invalid email or password");
         }


### PR DESCRIPTION
## Summary
- add MarketingProviders wrapper with SessionProvider and ThemeProvider
- use MarketingProviders in marketing layout
- fix credential typing in auth configuration

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bb151fcc1c8329b783d3ac6f99f087