### PR TITLE
feat: use AUTH_URL for auth callbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Render Postgres
 DATABASE_URL=postgresql://user:pass@host:5432/herobooks?sslmode=require
 
-# NextAuth
+# Auth.js
+# Prefer AUTH_URL/AUTH_SECRET; NEXTAUTH_* is retained for backward compatibility
+AUTH_URL=https://herobooks.net
+AUTH_SECRET=change_this_in_render
 NEXTAUTH_URL=https://herobooks.net
 NEXTAUTH_SECRET=change_this_in_render
 

--- a/src/app/api/subscribe/checkout/route.ts
+++ b/src/app/api/subscribe/checkout/route.ts
@@ -6,6 +6,7 @@ import { normalizePlan, type Plan } from "@/lib/plans";
 import { getPlanPriceGyd, applyPromo } from "@/lib/pricing";
 import { getProviderOrThrow } from "@/lib/payments";
 import { getActiveOrgId } from "@/lib/tenant";
+import { baseUrl } from "@/env";
 
 export async function POST(req: Request) {
   const session = await auth();
@@ -38,7 +39,7 @@ export async function POST(req: Request) {
     intentId: intent.id,
     amountGYD: finalAmount,
     description: `heroBooks ${plan} plan`,
-    returnUrl: `${process.env.NEXTAUTH_URL}/checkout/confirm`,
+    returnUrl: `${baseUrl}/checkout/confirm`,
     metadata: { plan },
   });
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,1 @@
+export const baseUrl = process.env.AUTH_URL || process.env.NEXTAUTH_URL!;

--- a/src/lib/payments/paypal.ts
+++ b/src/lib/payments/paypal.ts
@@ -1,4 +1,5 @@
 import { PaymentProvider, CreateCheckoutInput, CreateCheckoutResult } from "./types";
+import { baseUrl } from "@/env";
 
 const PAYPAL_BASE =
   process.env.PAYPAL_ENV === "live" ? "https://api-m.paypal.com" : "https://api-m.sandbox.paypal.com";
@@ -38,10 +39,8 @@ export const paypalProvider: PaymentProvider = {
             },
           ],
           application_context: {
-            return_url: `${process.env.NEXTAUTH_URL}/api/paypal/capture?intent=${encodeURIComponent(
-              input.intentId
-            )}`,
-            cancel_url: `${process.env.NEXTAUTH_URL}/checkout?cancel=1`,
+            return_url: `${baseUrl}/api/paypal/capture?intent=${encodeURIComponent(input.intentId)}`,
+            cancel_url: `${baseUrl}/checkout?cancel=1`,
             brand_name: "heroBooks",
             user_action: "PAY_NOW",
           },


### PR DESCRIPTION
## Summary
- add baseUrl helper that prefers `AUTH_URL` and falls back to `NEXTAUTH_URL`
- update PayPal provider and checkout route to use `baseUrl`
- document `AUTH_URL` and `AUTH_SECRET` in `.env.example`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb20594cec8329a7c6333af5150b56