### PR TITLE
Build NextAuth providers dynamically

### DIFF
--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -5,38 +5,47 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "@/lib/prisma";
 import { compare } from "bcryptjs";
 
+const providers: NextAuthConfig["providers"] = [];
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: true,
+    })
+  );
+}
+
+providers.push(
+  Credentials({
+    credentials: {
+      email: { label: "Email", type: "email" },
+      password: { label: "Password", type: "password" },
+    },
+    async authorize(credentials) {
+      const { email, password } = credentials as {
+        email?: string;
+        password?: string;
+      };
+      if (!email || !password) return null;
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user || !user.passwordHash) {
+        throw new Error("No user found");
+      }
+      const valid = await compare(password, user.passwordHash);
+      if (!valid) {
+        throw new Error("Invalid email or password");
+      }
+      return { id: user.id, email: user.email ?? undefined, name: user.name ?? undefined };
+    },
+  })
+);
+
 export const authConfig = {
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt", maxAge: 30 * 24 * 60 * 60 },
-  providers: [
-    Google({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
-      allowDangerousEmailAccountLinking: true,
-    }),
-    Credentials({
-      credentials: {
-        email: { label: "Email", type: "email" },
-        password: { label: "Password", type: "password" },
-      },
-      async authorize(credentials) {
-        const { email, password } = credentials as {
-          email?: string;
-          password?: string;
-        };
-        if (!email || !password) return null;
-        const user = await prisma.user.findUnique({ where: { email } });
-        if (!user || !user.passwordHash) {
-          throw new Error("No user found");
-        }
-        const valid = await compare(password, user.passwordHash);
-        if (!valid) {
-          throw new Error("Invalid email or password");
-        }
-        return { id: user.id, email: user.email ?? undefined, name: user.name ?? undefined };
-      },
-    }),
-  ],
+  providers,
   pages: {
     signIn: "/sign-in",
   },


### PR DESCRIPTION
## Summary
- Build providers array dynamically in auth config
- Include Google provider only when both Google env vars are present
- Keep credentials provider in all cases

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb205c22d48329bc0682aed8de9324