### PR TITLE
feat: add role column to user table

### DIFF
--- a/prisma/migrations/20250922000000_add_role_to_user/migration.sql
+++ b/prisma/migrations/20250922000000_add_role_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "role" TEXT NOT NULL DEFAULT 'user';


### PR DESCRIPTION
## Summary
- add migration to introduce `role` column to `User` with default `user`

## Testing
- `pnpm lint`
- `npx prisma migrate deploy`

------
https://chatgpt.com/codex/tasks/task_e_68bb205b019c8329aaa05d31ed5f309f