### PR TITLE
feat: add demo sandbox with 72h TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,8 @@
 # Demo sandbox (shared company)
-# Set this in Render. Value = the Org.id of your shared demo company.
+# DEMO_ORG_ID can be either the Org.id *or* the Org.name to use (we'll resolve or create it).
 DEMO_ORG_ID=
 
-# Optional: TTL for demo data in hours (used by opportunistic purge logic).
-# Code defaults to 72 if unset.
+# Optional: TTL for demo data in hours (defaults to 72)
 DEMO_TTL_HOURS=72
 
 # Render Postgres

--- a/prisma/migrations/20250905000000_demo_ephemeral_writes/migration.sql
+++ b/prisma/migrations/20250905000000_demo_ephemeral_writes/migration.sql
@@ -1,0 +1,48 @@
+-- Add ephemeral demo fields to key tables
+ALTER TABLE "Customer"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoSessionId" TEXT,
+  ADD COLUMN "expiresAt" TIMESTAMP;
+CREATE INDEX "Customer_orgId_isDemo_idx" ON "Customer"("orgId","isDemo");
+CREATE INDEX "Customer_isDemo_expiresAt_idx" ON "Customer"("isDemo","expiresAt");
+CREATE INDEX "Customer_isDemo_demoSessionId_idx" ON "Customer"("isDemo","demoSessionId");
+
+ALTER TABLE "Item"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoSessionId" TEXT,
+  ADD COLUMN "expiresAt" TIMESTAMP;
+CREATE INDEX "Item_orgId_isDemo_idx" ON "Item"("orgId","isDemo");
+CREATE INDEX "Item_isDemo_expiresAt_idx" ON "Item"("isDemo","expiresAt");
+CREATE INDEX "Item_isDemo_demoSessionId_idx" ON "Item"("isDemo","demoSessionId");
+
+ALTER TABLE "Invoice"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoSessionId" TEXT,
+  ADD COLUMN "expiresAt" TIMESTAMP;
+CREATE INDEX "Invoice_orgId_isDemo_idx" ON "Invoice"("orgId","isDemo");
+CREATE INDEX "Invoice_isDemo_expiresAt_idx" ON "Invoice"("isDemo","expiresAt");
+CREATE INDEX "Invoice_isDemo_demoSessionId_idx" ON "Invoice"("isDemo","demoSessionId");
+
+ALTER TABLE "Estimate"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoSessionId" TEXT,
+  ADD COLUMN "expiresAt" TIMESTAMP;
+CREATE INDEX "Estimate_orgId_isDemo_idx" ON "Estimate"("orgId","isDemo");
+CREATE INDEX "Estimate_isDemo_expiresAt_idx" ON "Estimate"("isDemo","expiresAt");
+CREATE INDEX "Estimate_isDemo_demoSessionId_idx" ON "Estimate"("isDemo","demoSessionId");
+
+ALTER TABLE "Payment"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoSessionId" TEXT,
+  ADD COLUMN "expiresAt" TIMESTAMP;
+CREATE INDEX "Payment_orgId_isDemo_idx" ON "Payment"("orgId","isDemo");
+CREATE INDEX "Payment_isDemo_expiresAt_idx" ON "Payment"("isDemo","expiresAt");
+CREATE INDEX "Payment_isDemo_demoSessionId_idx" ON "Payment"("isDemo","demoSessionId");
+
+ALTER TABLE "BankTransaction"
+  ADD COLUMN "isDemo" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "demoSessionId" TEXT,
+  ADD COLUMN "expiresAt" TIMESTAMP;
+CREATE INDEX "BankTransaction_orgId_isDemo_idx" ON "BankTransaction"("orgId","isDemo");
+CREATE INDEX "BankTransaction_isDemo_expiresAt_idx" ON "BankTransaction"("isDemo","expiresAt");
+CREATE INDEX "BankTransaction_isDemo_demoSessionId_idx" ON "BankTransaction"("isDemo","demoSessionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,8 +137,14 @@ model Customer {
   org       Org        @relation(fields: [orgId], references: [id])
   invoices  Invoice[]
   estimates Estimate[]
+  isDemo        Boolean  @default(false)
+  demoSessionId String?
+  expiresAt     DateTime?
 
   @@unique([id, orgId])
+  @@index([orgId, isDemo])
+  @@index([isDemo, expiresAt])
+  @@index([isDemo, demoSessionId])
 }
 
 model TaxCode {
@@ -167,8 +173,14 @@ model Item {
   taxCode      TaxCode?      @relation(fields: [taxCodeId, orgId], references: [id, orgId])
   invoiceLines InvoiceLine[]
   billLines    BillLine[]
+  isDemo        Boolean  @default(false)
+  demoSessionId String?
+  expiresAt     DateTime?
 
   @@unique([id, orgId])
+  @@index([orgId, isDemo])
+  @@index([isDemo, expiresAt])
+  @@index([isDemo, demoSessionId])
 }
 
 model Invoice {
@@ -184,9 +196,15 @@ model Invoice {
   lines            InvoiceLine[]
   payments         Payment[]
   bankTransactions BankTransaction[]
+  isDemo        Boolean  @default(false)
+  demoSessionId String?
+  expiresAt     DateTime?
 
   @@unique([id, orgId])
   @@unique([orgId, number])
+  @@index([orgId, isDemo])
+  @@index([isDemo, expiresAt])
+  @@index([isDemo, demoSessionId])
 }
 
 model InvoiceLine {
@@ -215,8 +233,14 @@ model Payment {
   date             DateTime          @default(now())
   invoice          Invoice           @relation(fields: [invoiceId, orgId], references: [id, orgId])
   bankTransactions BankTransaction[]
+  isDemo        Boolean  @default(false)
+  demoSessionId String?
+  expiresAt     DateTime?
 
   @@unique([id, orgId])
+  @@index([orgId, isDemo])
+  @@index([isDemo, expiresAt])
+  @@index([isDemo, demoSessionId])
 }
 
 model Vendor {
@@ -276,9 +300,15 @@ model Estimate {
   org        Org            @relation(fields: [orgId], references: [id])
   customer   Customer?      @relation(fields: [customerId, orgId], references: [id, orgId])
   lines      EstimateLine[]
+  isDemo        Boolean  @default(false)
+  demoSessionId String?
+  expiresAt     DateTime?
 
   @@unique([id, orgId])
   @@unique([orgId, number])
+  @@index([orgId, isDemo])
+  @@index([isDemo, expiresAt])
+  @@index([isDemo, demoSessionId])
 }
 
 model EstimateLine {
@@ -312,9 +342,15 @@ model BankTransaction {
   invoice   Invoice? @relation(fields: [invoiceId, orgId], references: [id, orgId])
   payment   Payment? @relation(fields: [paymentId, orgId], references: [id, orgId])
   bill      Bill?    @relation(fields: [billId, orgId], references: [id, orgId])
+  isDemo        Boolean  @default(false)
+  demoSessionId String?
+  expiresAt     DateTime?
 
   @@unique([id, orgId])
   @@index([orgId, date])
+  @@index([orgId, isDemo])
+  @@index([isDemo, expiresAt])
+  @@index([isDemo, demoSessionId])
 }
 
 model OrgTheme {

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,7 +9,7 @@ export const dynamic = "force-dynamic";
 
 export default async function DashboardPage() {
   const session = await auth();
-  const demo = isDemoSession(session);
+  const demo = await isDemoSession(session);
   const noRealOrg = !demo && !(session as any)?.orgId;
   let data: Awaited<ReturnType<typeof getDashboardData>> | null = null;
   if (!noRealOrg) {

--- a/src/app/api/bank/transactions/route.ts
+++ b/src/app/api/bank/transactions/route.ts
@@ -1,24 +1,37 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import {
+  isDemoSession,
+  demoReadWhere,
+  resolveActiveOrgId,
+  purgeExpiredDemoDataIfAny,
+} from "@/lib/demo";
 
 export async function GET() {
   const session = await auth();
   if (!session?.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
-  const userId = session.user.id;
-  const userOrg = await prisma.userOrg.findFirst({
-    where: { userId },
-    select: { orgId: true }
-  });
-  if (!userOrg) {
+  if (await isDemoSession(session)) {
+    await purgeExpiredDemoDataIfAny();
+    const where = await demoReadWhere(session);
+    const transactions = await prisma.bankTransaction.findMany({
+      where,
+      orderBy: { date: "desc" },
+      take: 50,
+    });
+    return NextResponse.json(transactions);
+  }
+  const orgId = await resolveActiveOrgId(session);
+  if (!orgId) {
     return new NextResponse("No organization", { status: 400 });
   }
   const transactions = await prisma.bankTransaction.findMany({
-    where: { orgId: userOrg.orgId },
+    where: { orgId },
     orderBy: { date: "desc" },
-    take: 50
+    take: 50,
   });
   return NextResponse.json(transactions);
 }
+

--- a/src/app/api/demo/enter/route.ts
+++ b/src/app/api/demo/enter/route.ts
@@ -1,17 +1,16 @@
 import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
-import { assertDemoConfigured, purgeExpiredDemoDataIfAny, DEMO_ORG_ID } from "@/lib/demo";
+import { purgeExpiredDemoDataIfAny, getDemoOrgId } from "@/lib/demo";
 
 export async function POST() {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ ok: false, error: "Not authenticated" }, { status: 401 });
   }
-  assertDemoConfigured();
-
   await purgeExpiredDemoDataIfAny();
+  const orgId = await getDemoOrgId();
   // @ts-ignore next-auth v5 session update
-  await session.update({ demo: true, orgId: DEMO_ORG_ID });
-  return NextResponse.json({ ok: true });
+  await session.update({ demo: true, orgId });
+  return NextResponse.json({ ok: true, orgId });
 }
 

--- a/src/app/api/demo/leave/route.ts
+++ b/src/app/api/demo/leave/route.ts
@@ -7,7 +7,7 @@ export async function POST() {
   if (!session?.user?.id) {
     return NextResponse.json({ ok: false, error: "Not authenticated" }, { status: 401 });
   }
-  // Opportunistic cleanup (TTL) — safe no-op for now
+  // Opportunistic expired purge
   await purgeExpiredDemoDataIfAny();
 
   // Unset demo and fall back to the user's last real org (kept in your own session.orgId handling)

--- a/src/app/api/email/send-invoice/route.ts
+++ b/src/app/api/email/send-invoice/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: Request) {
     })
   ).html;
 
-  if (isDemoSession(session)) {
+  if (await isDemoSession(session)) {
     const allowSendToSelf = form.get("sendToSelf")?.toString() === "true";
     if (!allowSendToSelf) {
       return NextResponse.json({ ok: true, mode: "preview", html });

--- a/src/app/api/email/send-receipt/route.ts
+++ b/src/app/api/email/send-receipt/route.ts
@@ -55,7 +55,7 @@ export async function POST(req: Request) {
     })
   ).html;
 
-  if (isDemoSession(session)) {
+  if (await isDemoSession(session)) {
     const allowSendToSelf = Boolean(sendToSelf);
     if (!allowSendToSelf) {
       return NextResponse.json({ ok: true, mode: "preview", html });

--- a/src/app/api/estimates/route.ts
+++ b/src/app/api/estimates/route.ts
@@ -3,6 +3,14 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { calcLines, nextDocNumber } from "@/lib/vatCalc";
 import { Prisma } from "@prisma/client";
+import {
+  isDemoSession,
+  demoReadWhere,
+  withDemoWrite,
+  resolveActiveOrgId,
+  purgeExpiredDemoDataIfAny,
+  getDemoOrgId,
+} from "@/lib/demo";
 
 interface EstimateItemInput {
   description: string;
@@ -13,43 +21,31 @@ interface EstimateItemInput {
 
 export async function GET() {
   const session = await auth();
-  if (!session?.user?.id) {
-    return new NextResponse("Unauthorized", { status: 401 });
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  if (await isDemoSession(session)) {
+    await purgeExpiredDemoDataIfAny();
+    const where = await demoReadWhere(session);
+    const estimates = await prisma.estimate.findMany({ where, include: { customer: true } });
+    return NextResponse.json(estimates);
   }
-  const userId = session.user.id;
-  const userOrg = await prisma.userOrg.findFirst({
-    where: { userId },
-    select: { orgId: true }
-  });
-  if (!userOrg) {
-    return new NextResponse("No organization", { status: 400 });
-  }
-  const estimates = await prisma.estimate.findMany({
-    where: { orgId: userOrg.orgId },
-    include: { customer: true }
-  });
+  const orgId = await resolveActiveOrgId(session);
+  if (!orgId) return new NextResponse("No organization", { status: 400 });
+  const estimates = await prisma.estimate.findMany({ where: { orgId }, include: { customer: true } });
   return NextResponse.json(estimates);
 }
 
 export async function POST(req: Request) {
   const session = await auth();
-  if (!session?.user?.id) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
-  const userId = session.user.id;
-  const userOrg = await prisma.userOrg.findFirst({
-    where: { userId },
-    select: { orgId: true }
-  });
-  if (!userOrg) {
-    return new NextResponse("No organization", { status: 400 });
-  }
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  const demo = await isDemoSession(session);
+  const orgId = demo ? await getDemoOrgId() : await resolveActiveOrgId(session);
+  if (!orgId) return new NextResponse("No organization", { status: 400 });
   const body = await req.json();
   const { customerId, items }: { customerId: string; items: EstimateItemInput[] } = body;
 
   const customer = await prisma.customer.findFirst({
-    where: { id: customerId, orgId: userOrg.orgId },
-    select: { id: true }
+    where: { id: customerId, orgId },
+    select: { id: true },
   });
   if (!customer) {
     return new NextResponse("Not found", { status: 404 });
@@ -64,8 +60,8 @@ export async function POST(req: Request) {
     let taxCodeId: string | undefined = undefined;
     if (item.taxCodeId) {
       const tc = await prisma.taxCode.findFirst({
-        where: { id: item.taxCodeId, orgId: userOrg.orgId },
-        select: { id: true, rate: true }
+        where: { id: item.taxCodeId, orgId },
+        select: { id: true, rate: true },
       });
       if (!tc) {
         return new NextResponse("Not found", { status: 404 });
@@ -78,24 +74,36 @@ export async function POST(req: Request) {
       description: item.description,
       quantity: item.quantity,
       unitPrice: new Prisma.Decimal(item.unitPrice),
-      taxCodeId
+      taxCodeId,
     });
   }
 
   const totals = calcLines(vatInputs);
 
+  const data = demo
+    ? await withDemoWrite(session, {
+        customerId: customer.id,
+        number,
+        subTotal: new Prisma.Decimal(totals.subTotal),
+        vatTotal: new Prisma.Decimal(totals.vatTotal),
+        total: new Prisma.Decimal(totals.total),
+        lines: { create: lines },
+      })
+    : {
+        orgId,
+        customerId: customer.id,
+        number,
+        subTotal: new Prisma.Decimal(totals.subTotal),
+        vatTotal: new Prisma.Decimal(totals.vatTotal),
+        total: new Prisma.Decimal(totals.total),
+        lines: { create: lines },
+      };
+
   const estimate = await prisma.estimate.create({
-    data: {
-      orgId: userOrg.orgId,
-      customerId: customer.id,
-      number,
-      subTotal: new Prisma.Decimal(totals.subTotal),
-      vatTotal: new Prisma.Decimal(totals.vatTotal),
-      total: new Prisma.Decimal(totals.total),
-      lines: { create: lines }
-    },
-    include: { lines: true, customer: true }
+    data,
+    include: { lines: true, customer: true },
   });
 
-  return NextResponse.json(estimate);
+  return NextResponse.json(demo ? { ...estimate, demo: true } : estimate);
 }
+

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -4,6 +4,14 @@ import { prisma } from "@/lib/prisma";
 import { invoiceNumber } from "@/lib/numbering";
 import { notifyWebhook } from "@/lib/webhooks";
 import { Prisma } from "@prisma/client";
+import {
+  isDemoSession,
+  demoReadWhere,
+  withDemoWrite,
+  resolveActiveOrgId,
+  purgeExpiredDemoDataIfAny,
+  getDemoOrgId,
+} from "@/lib/demo";
 
 interface InvoiceItemInput {
   itemId?: string;
@@ -15,43 +23,31 @@ interface InvoiceItemInput {
 
 export async function GET() {
   const session = await auth();
-  if (!session?.user?.id) {
-    return new NextResponse("Unauthorized", { status: 401 });
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  if (await isDemoSession(session)) {
+    await purgeExpiredDemoDataIfAny();
+    const where = await demoReadWhere(session);
+    const invoices = await prisma.invoice.findMany({ where, include: { customer: true } });
+    return NextResponse.json(invoices);
   }
-  const userId = session.user.id;
-  const userOrg = await prisma.userOrg.findFirst({
-    where: { userId },
-    select: { orgId: true }
-  });
-  if (!userOrg) {
-    return new NextResponse("No organization", { status: 400 });
-  }
-  const invoices = await prisma.invoice.findMany({
-    where: { orgId: userOrg.orgId },
-    include: { customer: true }
-  });
+  const orgId = await resolveActiveOrgId(session);
+  if (!orgId) return new NextResponse("No organization", { status: 400 });
+  const invoices = await prisma.invoice.findMany({ where: { orgId }, include: { customer: true } });
   return NextResponse.json(invoices);
 }
 
 export async function POST(req: Request) {
   const session = await auth();
-  if (!session?.user?.id) {
-    return new NextResponse("Unauthorized", { status: 401 });
-  }
-  const userId = session.user.id;
-  const userOrg = await prisma.userOrg.findFirst({
-    where: { userId },
-    select: { orgId: true }
-  });
-  if (!userOrg) {
-    return new NextResponse("No organization", { status: 400 });
-  }
+  if (!session?.user?.id) return new NextResponse("Unauthorized", { status: 401 });
+  const demo = await isDemoSession(session);
+  const orgId = demo ? await getDemoOrgId() : await resolveActiveOrgId(session);
+  if (!orgId) return new NextResponse("No organization", { status: 400 });
   const body = await req.json();
   const { customerId, items }: { customerId: string; items: InvoiceItemInput[] } = body;
 
   const org = await prisma.org.findUnique({
-    where: { id: userOrg.orgId },
-    include: { settings: true }
+    where: { id: orgId },
+    include: { settings: true },
   });
   const allowNegativeStock = org?.settings?.allowNegativeStock ?? false;
 
@@ -60,8 +56,8 @@ export async function POST(req: Request) {
   try {
     const invoice = await prisma.$transaction(async (tx) => {
       const customer = await tx.customer.findFirst({
-        where: { id: customerId, orgId: userOrg.orgId },
-        select: { id: true }
+        where: { id: customerId, orgId },
+        select: { id: true },
       });
       if (!customer) {
         throw new Error("CUSTOMER_NOT_FOUND");
@@ -70,23 +66,25 @@ export async function POST(req: Request) {
       for (const item of items) {
         if (item.itemId) {
           const dbItem = await tx.item.findFirst({
-            where: { id: item.itemId, orgId: userOrg.orgId }
+            where: { id: item.itemId, orgId },
           });
           if (!dbItem) {
             throw new Error("ITEM_NOT_FOUND");
           }
-          if (!allowNegativeStock && dbItem.qtyOnHand < item.quantity) {
-            throw new Error("INSUFFICIENT_STOCK");
+          if (!demo) {
+            if (!allowNegativeStock && dbItem.qtyOnHand < item.quantity) {
+              throw new Error("INSUFFICIENT_STOCK");
+            }
+            await tx.item.update({
+              where: { id: dbItem.id },
+              data: { qtyOnHand: dbItem.qtyOnHand - item.quantity },
+            });
           }
-          await tx.item.update({
-            where: { id: dbItem.id },
-            data: { qtyOnHand: dbItem.qtyOnHand - item.quantity }
-          });
           let taxCodeId = item.taxCodeId ?? dbItem.taxCodeId ?? undefined;
           if (taxCodeId) {
             const tc = await tx.taxCode.findFirst({
-              where: { id: taxCodeId, orgId: userOrg.orgId },
-              select: { id: true }
+              where: { id: taxCodeId, orgId },
+              select: { id: true },
             });
             if (!tc) {
               throw new Error("TAXCODE_NOT_FOUND");
@@ -98,15 +96,15 @@ export async function POST(req: Request) {
             description: item.description ?? dbItem.description,
             quantity: item.quantity,
             unitPrice: new Prisma.Decimal(item.unitPrice ?? dbItem.price),
-            taxCodeId: taxCodeId
+            taxCodeId,
           });
           continue;
         }
         let manualTaxCodeId = item.taxCodeId;
         if (manualTaxCodeId) {
           const tc = await tx.taxCode.findFirst({
-            where: { id: manualTaxCodeId, orgId: userOrg.orgId },
-            select: { id: true }
+            where: { id: manualTaxCodeId, orgId },
+            select: { id: true },
           });
           if (!tc) {
             throw new Error("TAXCODE_NOT_FOUND");
@@ -117,21 +115,25 @@ export async function POST(req: Request) {
           description: item.description ?? "",
           quantity: item.quantity,
           unitPrice: new Prisma.Decimal(item.unitPrice ?? 0),
-          taxCodeId: manualTaxCodeId
+          taxCodeId: manualTaxCodeId,
         });
       }
-      return tx.invoice.create({
-        data: {
-          orgId: userOrg.orgId,
-          customerId: customer.id,
-          number,
-          lines: { create: lines }
-        },
-        include: { lines: true, customer: true }
-      });
+      const data = demo
+        ? await withDemoWrite(session, {
+            customerId: customer.id,
+            number,
+            lines: { create: lines },
+          })
+        : {
+            orgId,
+            customerId: customer.id,
+            number,
+            lines: { create: lines },
+          };
+      return tx.invoice.create({ data, include: { lines: true, customer: true } });
     });
-    await notifyWebhook(userOrg.orgId, "invoice.created", invoice);
-    return NextResponse.json(invoice);
+    if (!demo) await notifyWebhook(orgId, "invoice.created", invoice);
+    return NextResponse.json(demo ? { ...invoice, demo: true } : invoice);
   } catch (err: any) {
     if (
       err.message === "ITEM_NOT_FOUND" ||
@@ -146,3 +148,4 @@ export async function POST(req: Request) {
     throw err;
   }
 }
+

--- a/src/app/api/items/route.ts
+++ b/src/app/api/items/route.ts
@@ -15,12 +15,12 @@ export async function GET() {
   if (await isDemoSession(session)) {
     await purgeExpiredDemoDataIfAny();
     const where = await demoReadWhere(session);
-    const data = await prisma.customer.findMany({ where, orderBy: { createdAt: "desc" } });
+    const data = await prisma.item.findMany({ where, orderBy: { name: "asc" } });
     return NextResponse.json(data);
   }
   const orgId = await resolveActiveOrgId(session);
-  const customers = await prisma.customer.findMany({ where: { orgId }, orderBy: { createdAt: "desc" } });
-  return NextResponse.json(customers);
+  const items = await prisma.item.findMany({ where: { orgId }, orderBy: { name: "asc" } });
+  return NextResponse.json(items);
 }
 
 export async function POST(req: Request) {
@@ -29,11 +29,11 @@ export async function POST(req: Request) {
   const body = await req.json();
   if (await isDemoSession(session)) {
     await purgeExpiredDemoDataIfAny();
-    const data = await prisma.customer.create({ data: await withDemoWrite(session, body) });
+    const data = await prisma.item.create({ data: await withDemoWrite(session, body) });
     return NextResponse.json({ ...data, demo: true });
   }
   const orgId = await resolveActiveOrgId(session);
-  const data = await prisma.customer.create({ data: { ...body, orgId } });
+  const data = await prisma.item.create({ data: { ...body, orgId } });
   return NextResponse.json(data);
 }
 

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -5,11 +5,18 @@ import { receiptNumber } from "@/lib/numbering";
 import { notifyWebhook } from "@/lib/webhooks";
 import { Prisma } from "@prisma/client";
 import { z } from "zod";
+import {
+  isDemoSession,
+  withDemoWrite,
+  resolveActiveOrgId,
+  purgeExpiredDemoDataIfAny,
+  getDemoOrgId,
+} from "@/lib/demo";
 
 const PaymentSchema = z.object({
   invoiceId: z.string(),
   amount: z.number().positive(),
-  method: z.string()
+  method: z.string(),
 });
 
 export async function POST(req: Request) {
@@ -18,13 +25,13 @@ export async function POST(req: Request) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const userId = session.user.id;
-  const userOrg = await prisma.userOrg.findFirst({
-    where: { userId },
-    select: { orgId: true }
-  });
-  if (!userOrg) {
+  const demo = await isDemoSession(session);
+  const orgId = demo ? await getDemoOrgId() : await resolveActiveOrgId(session);
+  if (!orgId) {
     return new NextResponse("No organization", { status: 400 });
+  }
+  if (demo) {
+    await purgeExpiredDemoDataIfAny();
   }
 
   const body = await req.json();
@@ -35,24 +42,32 @@ export async function POST(req: Request) {
 
   const { invoiceId, amount, method } = parsed.data;
   const invoice = await prisma.invoice.findFirst({
-    where: { id: invoiceId, orgId: userOrg.orgId }
+    where: { id: invoiceId, orgId },
   });
   if (!invoice) {
     return new NextResponse("Not found", { status: 404 });
   }
 
   const number = await receiptNumber();
-  const payment = await prisma.payment.create({
-    data: {
-      invoiceId,
-      orgId: userOrg.orgId,
-      amount: new Prisma.Decimal(amount),
-      method,
-      receiptNumber: number
-    }
-  });
+  const data = demo
+    ? await withDemoWrite(session, {
+        invoiceId,
+        amount: new Prisma.Decimal(amount),
+        method,
+        receiptNumber: number,
+      })
+    : {
+        orgId,
+        invoiceId,
+        amount: new Prisma.Decimal(amount),
+        method,
+        receiptNumber: number,
+      };
+
+  const payment = await prisma.payment.create({ data });
 
   await prisma.invoice.update({ where: { id: invoiceId }, data: { status: "paid" } });
-  await notifyWebhook(invoice.orgId, "payment.created", payment);
-  return NextResponse.json({ paymentId: payment.id, receiptNumber: number, status: "paid" });
+  if (!demo) await notifyWebhook(invoice.orgId, "payment.created", payment);
+  return NextResponse.json({ paymentId: payment.id, receiptNumber: number, status: "paid", demo });
 }
+

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -6,7 +6,7 @@ import { isDemoSession } from "@/lib/demo";
 
 export default async function Topbar() {
   const session = await auth();
-  const demo = isDemoSession(session);
+  const demo = await isDemoSession(session);
 
   return (
     <header className="h-14 border-b bg-background/60 backdrop-blur flex items-center justify-between px-4">

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -1,36 +1,108 @@
 import type { Session } from "next-auth";
 import { prisma } from "@/lib/prisma";
 
-export const DEMO_ORG_ID = process.env.DEMO_ORG_ID;
+const RAW_DEMO_ORG = process.env.DEMO_ORG_ID || "";
 const DEMO_TTL_HOURS = Number(process.env.DEMO_TTL_HOURS || "72");
 
-/** Is current session in demo mode? */
-export function isDemoSession(session: Session | null | undefined) {
-  return Boolean(session?.demo && DEMO_ORG_ID && session?.orgId === DEMO_ORG_ID);
+let cachedDemoOrgId: string | undefined;
+
+/**
+ * Resolve the demo org id:
+ * - If DEMO_ORG_ID looks like a cuid/uuid and matches an existing org, use it.
+ * - Otherwise, treat DEMO_ORG_ID as a name: find or create org with that name and return its id.
+ * Caches result for this process.
+ */
+export async function getDemoOrgId(): Promise<string> {
+  if (cachedDemoOrgId) return cachedDemoOrgId;
+  const val = RAW_DEMO_ORG.trim();
+  if (!val) throw new Error("DEMO_ORG_ID not configured");
+
+  // Try by id first
+  const existingById = await prisma.org.findFirst({ where: { id: val }, select: { id: true } });
+  if (existingById) {
+    cachedDemoOrgId = existingById.id;
+    return cachedDemoOrgId;
+  }
+
+  // Otherwise treat as name
+  let byName = await prisma.org.findFirst({ where: { name: val }, select: { id: true } });
+  if (!byName) {
+    byName = await prisma.org.create({
+      data: { name: val },
+      select: { id: true },
+    });
+  }
+  cachedDemoOrgId = byName.id;
+  return cachedDemoOrgId!;
+}
+
+/** Is current session in demo mode (and demo org configured)? */
+export async function isDemoSession(session: Session | null | undefined) {
+  if (!session?.demo) return false;
+  const demoOrgId = await getDemoOrgId();
+  return Boolean(session?.orgId === demoOrgId);
 }
 
 /** Resolve active orgId based on session (demo takes precedence) */
-export function resolveActiveOrgId(session: Session | null | undefined): string | undefined {
+export async function resolveActiveOrgId(session: Session | null | undefined): Promise<string | undefined> {
   if (!session?.user?.id) return undefined;
-  if (isDemoSession(session)) return DEMO_ORG_ID as string;
+  if (await isDemoSession(session)) return getDemoOrgId();
   return (session as any).orgId as string | undefined; // set by your org switcher
-}
-
-/** Opportunistically purge expired demo rows (if you later add demo columns). */
-export async function purgeExpiredDemoDataIfAny() {
-  // Placeholder for future ephemeral DB purge — safe no-op today.
-  return;
-}
-
-/** Ensure demo config is healthy before entering demo. */
-export function assertDemoConfigured() {
-  if (!DEMO_ORG_ID) {
-    throw new Error("DEMO_ORG_ID not configured");
-  }
 }
 
 /** TTL helper in ms */
 export function demoTtlMs() {
   return DEMO_TTL_HOURS * 60 * 60 * 1000;
+}
+
+/** Delete expired demo rows (cheap, index-backed). Safe no-op if models absent. */
+export async function purgeExpiredDemoDataIfAny() {
+  const now = new Date();
+  // Extend this list if you add more demo-enabled tables
+  await Promise.allSettled([
+    prisma.invoice.deleteMany({ where: { isDemo: true, expiresAt: { lt: now } } }),
+    prisma.payment.deleteMany({ where: { isDemo: true, expiresAt: { lt: now } } }),
+    prisma.estimate.deleteMany({ where: { isDemo: true, expiresAt: { lt: now } } }),
+    prisma.customer.deleteMany({ where: { isDemo: true, expiresAt: { lt: now } } }),
+    prisma.item.deleteMany({ where: { isDemo: true, expiresAt: { lt: now } } }),
+    prisma.bankTransaction.deleteMany({ where: { isDemo: true, expiresAt: { lt: now } } }),
+  ]);
+}
+
+/** Patch a write for demo: stamp orgId, isDemo, demoSessionId, expiresAt, createdByUserId. */
+export async function withDemoWrite<T extends Record<string, any>>(session: Session, body: T) {
+  const orgId = await getDemoOrgId();
+  return {
+    ...body,
+    orgId,
+    isDemo: true,
+    demoSessionId: session.demoSessionId,
+    expiresAt: new Date(Date.now() + demoTtlMs()),
+  };
+}
+
+/** Demo read filter: only seed(!isDemo) + my ephemeral (isDemo + my session) for this org */
+export async function demoReadWhere(session: Session) {
+  const orgId = await getDemoOrgId();
+  return {
+    orgId,
+    OR: [
+      { isDemo: false }, // seeded
+      { isDemo: true, demoSessionId: session.demoSessionId },
+    ],
+  };
+}
+
+/** In demo, block org-level settings change by stripping known fields. */
+export function stripOrgSettings<T extends Record<string, any>>(data: T) {
+  const copy: Record<string, any> = { ...data };
+  delete copy.companyName;
+  delete copy.logoUrl;
+  delete copy.address;
+  delete copy.phone;
+  delete copy.taxNumber;
+  delete copy.vatSettings;
+  delete copy.numbering; // etc — adjust to your model
+  return copy as T;
 }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -8,7 +8,7 @@ declare module "next-auth" {
       name?: string | null;
     };
     demo?: boolean;
-    orgId?: string;          // active org for the session (demo uses DEMO_ORG_ID)
+    orgId?: string;          // active org for the session (demo uses resolved DEMO_ORG_ID)
     demoSessionId?: string;  // per-session UUID for demo isolation
   }
 }


### PR DESCRIPTION
## Summary
- resolve or seed demo org by name or id and isolate demo sessions
- tag demo writes with session TTL and restrict demo reads across key APIs
- add schema fields and migration for ephemeral demo data

## Testing
- `pnpm lint`
- `npx prisma generate`
- `npx prisma migrate dev --name demo_ephemeral_writes` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bb45ab6a848329aa5c499f9ad279ec