### PR TITLE
feat: add demo seed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "prisma migrate deploy && next start",
     "postinstall": "prisma generate",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed:demo": "tsx scripts/seed-demo.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -1,0 +1,361 @@
+/* eslint-disable no-console */
+import { prisma } from "@/lib/prisma";
+import { getDemoOrgId } from "@/lib/demo";
+import { VAT_CODES, SEED_CUSTOMERS, SEED_VENDORS, SEED_ITEMS, SEED_DOCS } from "@/lib/seed/demo-data";
+import { Decimal } from "@prisma/client/runtime/library";
+
+async function upsertDemoOrg(): Promise<string> {
+  // getDemoOrgId resolves or creates the demo org (by name or id)
+  const orgId = await getDemoOrgId();
+  const org = await prisma.org.findUnique({ where: { id: orgId } });
+  if (!org) throw new Error("Demo org resolution failed");
+  console.log(`Demo Org: ${org.name} (${org.id})`);
+  return orgId;
+}
+
+async function seedVat(orgId: string) {
+  for (const v of VAT_CODES) {
+    const existing = await prisma.taxCode.findFirst({ where: { orgId, name: v.name } });
+    if (existing) {
+      if (existing.rate !== v.rate) {
+        await prisma.taxCode.update({ where: { id: existing.id }, data: { rate: v.rate } });
+      }
+      continue;
+    }
+    await prisma.taxCode.create({ data: { orgId, name: v.name, rate: v.rate } });
+  }
+  console.log("✓ VAT codes");
+}
+
+async function seedCustomers(orgId: string) {
+  for (const c of SEED_CUSTOMERS) {
+    const found = await prisma.customer.findFirst({ where: { orgId, name: c.name } });
+    if (found) {
+      // keep email fresh if changed
+      if (c.email && c.email !== found.email) {
+        await prisma.customer.update({ where: { id: found.id }, data: { email: c.email } });
+      }
+      continue;
+    }
+    await prisma.customer.create({
+      data: { orgId, name: c.name, email: c.email ?? null },
+    });
+  }
+  console.log("✓ Customers");
+}
+
+async function seedVendors(orgId: string) {
+  for (const v of SEED_VENDORS) {
+    // You have @@unique([orgId, name]) on Vendor, so we can upsert by that
+    await prisma.vendor.upsert({
+      where: { orgId_name: { orgId, name: v.name } },
+      create: { orgId, name: v.name, email: v.email ?? null },
+      update: { email: v.email ?? null },
+    });
+  }
+  console.log("✓ Vendors");
+}
+
+async function seedItems(orgId: string) {
+  // Build tax index by name
+  const taxes = await prisma.taxCode.findMany({ where: { orgId } });
+  const taxByName = new Map(taxes.map((t) => [t.name, t]));
+
+  for (const it of SEED_ITEMS) {
+    const tax = taxByName.get(it.tax);
+    const found = await prisma.item.findFirst({ where: { orgId, name: it.name } });
+    if (found) {
+      await prisma.item.update({
+        where: { id: found.id },
+        data: { price: it.price, taxCodeId: tax?.id },
+      });
+      continue;
+    }
+    await prisma.item.create({
+      data: { orgId, name: it.name, price: it.price, taxCodeId: tax?.id ?? null },
+    });
+  }
+  console.log("✓ Items");
+}
+
+async function seedInvoices(orgId: string) {
+  // Build indices
+  const customers = await prisma.customer.findMany({ where: { orgId } });
+  const items = await prisma.item.findMany({ where: { orgId } });
+  const taxes = await prisma.taxCode.findMany({ where: { orgId } });
+  const custByName = new Map(customers.map((c) => [c.name, c]));
+  const itemByName = new Map(items.map((i) => [i.name, i]));
+  const taxById = new Map(taxes.map((t) => [t.id, t]));
+  const taxByName = new Map(taxes.map((t) => [t.name, t]));
+
+  for (const inv of SEED_DOCS.invoices) {
+    const customer = custByName.get(inv.customer);
+    if (!customer) {
+      console.warn(`Skip invoice ${inv.number}: customer ${inv.customer} not found`);
+      continue;
+    }
+
+    const exists = await prisma.invoice.findUnique({
+      where: { orgId_number: { orgId, number: inv.number } },
+    });
+
+    const linesCreate = inv.lines.map((l) => {
+      const item = itemByName.get(l.item);
+      if (!item) throw new Error(`Item not found: ${l.item}`);
+      const qty = l.qty ?? 1;
+      const unitPrice = item.price as Decimal;
+      // prefer item.taxCodeId if set; else fall back to VAT14 by name
+      const taxId = item.taxCodeId ?? taxByName.get("VAT Standard 14%")?.id ?? null;
+
+      return {
+        orgId,
+        itemId: item.id,
+        quantity: qty,
+        unitPrice: unitPrice,
+        taxCodeId: taxId,
+        description: item.name,
+      };
+    });
+
+    if (!exists) {
+      await prisma.invoice.create({
+        data: {
+          orgId,
+          number: inv.number,
+          customerId: customer.id,
+          issueDate: new Date(inv.issueDate),
+          dueDate: inv.dueDate ? new Date(inv.dueDate) : null,
+          status: inv.status ?? "draft",
+          isDemo: false,
+          lines: { create: linesCreate as any },
+        },
+      });
+    } else {
+      await prisma.invoice.update({
+        where: { id: exists.id },
+        data: {
+          customerId: customer.id,
+          issueDate: new Date(inv.issueDate),
+          dueDate: inv.dueDate ? new Date(inv.dueDate) : null,
+          status: inv.status ?? exists.status,
+        },
+      });
+
+      // Ensure lines exist (simple approach: if none exist, create; else leave as-is)
+      const count = await prisma.invoiceLine.count({ where: { orgId, invoiceId: exists.id } });
+      if (count === 0) {
+        await prisma.invoice.update({
+          where: { id: exists.id },
+          data: { lines: { create: linesCreate as any } },
+        });
+      }
+    }
+
+    // Partial payment
+    if (inv.partialPayment && inv.partialPayment.gt(0)) {
+      const invoiceRecord = await prisma.invoice.findUnique({
+        where: { orgId_number: { orgId, number: inv.number } },
+        select: { id: true },
+      });
+      if (!invoiceRecord) continue;
+
+      const existingPayment = await prisma.payment.findFirst({
+        where: { orgId, receiptNumber: 5001 },
+      });
+      if (existingPayment) {
+        await prisma.payment.update({
+          where: { id: existingPayment.id },
+          data: { amount: inv.partialPayment, method: "Bank Transfer" },
+        });
+      } else {
+        await prisma.payment.create({
+          data: {
+            orgId,
+            invoiceId: invoiceRecord.id,
+            amount: inv.partialPayment,
+            method: "Bank Transfer",
+            receiptNumber: 5001,
+            date: new Date(inv.issueDate),
+            isDemo: false,
+          },
+        });
+      }
+    }
+  }
+  console.log("✓ Invoices (+lines) and demo Payment(s)");
+}
+
+async function seedEstimates(orgId: string) {
+  const customers = await prisma.customer.findMany({ where: { orgId } });
+  const items = await prisma.item.findMany({ where: { orgId } });
+  const taxes = await prisma.taxCode.findMany({ where: { orgId } });
+  const custByName = new Map(customers.map((c) => [c.name, c]));
+  const itemByName = new Map(items.map((i) => [i.name, i]));
+  const taxByName = new Map(taxes.map((t) => [t.name, t]));
+
+  for (const est of SEED_DOCS.estimates) {
+    const customer = custByName.get(est.customer);
+    if (!customer) {
+      console.warn(`Skip estimate ${est.number}: customer ${est.customer} not found`);
+      continue;
+    }
+
+    const exists = await prisma.estimate.findUnique({
+      where: { orgId_number: { orgId, number: est.number } },
+    });
+
+    const linesCreate = est.lines.map((l) => {
+      const item = itemByName.get(l.item);
+      if (!item) throw new Error(`Item not found: ${l.item}`);
+      const qty = l.qty ?? 1;
+      const unitPrice = item.price as Decimal;
+      const taxId = item.taxCodeId ?? taxByName.get("VAT Standard 14%")?.id ?? null;
+      return {
+        orgId,
+        quantity: qty,
+        unitPrice,
+        taxCodeId: taxId,
+        description: item.name,
+      };
+    });
+
+    if (!exists) {
+      // Your Estimate requires subTotal, vatTotal, total. We’ll compute simple sums.
+      const subTotal = linesCreate.reduce(
+        (acc, l) => acc.plus(l.unitPrice.mul(l.quantity)),
+        new Decimal(0)
+      );
+      const vatTotal = new Decimal(
+        linesCreate
+          .map((l) => {
+            // rough VAT calc: if tax is 14% name, apply 14%, else 0
+            // for precision you'd join TaxCode.rate, but we already have taxId only.
+            // To be precise, fetch rate now:
+            return l;
+          })
+          .reduce((acc, _l) => acc, 0)
+      );
+      // Recompute exactly with rates:
+      const taxCodes = await prisma.taxCode.findMany({ where: { orgId } });
+      const taxById = new Map(taxCodes.map((t) => [t.id, t.rate]));
+      const vatExact = linesCreate.reduce((acc, l) => {
+        const rate = l.taxCodeId ? taxById.get(l.taxCodeId) ?? 0 : 0;
+        const lineNet = (l.unitPrice as Decimal).mul(l.quantity);
+        return acc.plus(lineNet.mul(rate));
+      }, new Decimal(0));
+      const total = subTotal.plus(vatExact);
+
+      await prisma.estimate.create({
+        data: {
+          orgId,
+          number: est.number,
+          customerId: customer.id,
+          issueDate: new Date(est.issueDate),
+          expiryDate: est.expiryDate ? new Date(est.expiryDate) : null,
+          status: est.status ?? "draft",
+          subTotal,
+          vatTotal: vatExact,
+          total,
+          isDemo: false,
+          lines: { create: linesCreate as any },
+        },
+      });
+    } else {
+      await prisma.estimate.update({
+        where: { id: exists.id },
+        data: {
+          customerId: customer.id,
+          issueDate: new Date(est.issueDate),
+          expiryDate: est.expiryDate ? new Date(est.expiryDate) : null,
+          status: est.status ?? exists.status,
+        },
+      });
+    }
+  }
+  console.log("✓ Estimates (+lines)");
+}
+
+async function seedBank(orgId: string) {
+  // We’ll use a single demo bank/account pair on all rows for now
+  const bankName = "Demo Bank";
+  const accountNo = "000111222";
+
+  for (const bt of SEED_DOCS.bank) {
+    // simple CREDIT/DEBIT by amount sign
+    const type = bt.amount.greaterThan(0) ? "CREDIT" : "DEBIT";
+
+    await prisma.bankTransaction.upsert({
+      where: {
+        // No unique on ref; use (orgId, date, amount, memo?) pattern to keep idempotent-ish
+        // If you later add a unique ref per org, switch to that.
+        // Here we fake uniqueness by memo signature.
+        id: (
+          await prisma.bankTransaction.findFirst({
+            where: {
+              orgId,
+              date: new Date(bt.date),
+              amount: bt.amount,
+              memo: bt.description,
+            },
+            select: { id: true },
+          })
+        )?.id ?? "NOT-FOUND",
+      },
+      create: {
+        orgId,
+        bankName,
+        accountNo,
+        date: new Date(bt.date),
+        amount: bt.amount,
+        type,
+        memo: bt.description,
+        status: "UNMATCHED",
+        isDemo: false,
+      },
+      update: {
+        bankName,
+        accountNo,
+        type,
+        memo: bt.description,
+      },
+    }).catch(async () => {
+      // If update failed because NOT-FOUND id, just create
+      await prisma.bankTransaction.create({
+        data: {
+          orgId,
+          bankName,
+          accountNo,
+          date: new Date(bt.date),
+          amount: bt.amount,
+          type,
+          memo: bt.description,
+          status: "UNMATCHED",
+          isDemo: false,
+        },
+      });
+    });
+  }
+  console.log("✓ Bank transactions");
+}
+
+async function main() {
+  const orgId = await upsertDemoOrg();
+  await seedVat(orgId);
+  await seedCustomers(orgId);
+  await seedVendors(orgId);
+  await seedItems(orgId);
+  await seedInvoices(orgId);
+  await seedEstimates(orgId);
+  await seedBank(orgId);
+  console.log("Demo seed complete ✅");
+}
+
+main()
+  .catch((e) => {
+    console.error("Seed failed ❌", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/src/lib/seed/demo-data.ts
+++ b/src/lib/seed/demo-data.ts
@@ -1,0 +1,88 @@
+import { Decimal } from "@prisma/client/runtime/library";
+
+export const VAT_CODES = [
+  { name: "VAT Standard 14%", rate: 0.14 },
+  { name: "Zero-rated 0%", rate: 0 },
+  { name: "Exempt", rate: 0 },
+];
+
+// NOTE: Your schema does not expose Org-level PAYE/NIS/COA storage.
+// If/when you add those tables/fields, we’ll seed them here.
+// export const PAYE = { ... }
+// export const NIS = { ... }
+// export const COA = { ... }
+
+export const SEED_CUSTOMERS = [
+  { name: "ACME Trading", email: "acme@example.com" },
+  { name: "Georgetown Retailers", email: "shop@gt-retail.gy" },
+  { name: "New Amsterdam Hardware", email: "nah@example.gy" },
+];
+
+export const SEED_VENDORS = [
+  { name: "MMG Services", email: "vendors@mmg.gy" },
+  { name: "GPL", email: "billing@gpl.gy" },
+  { name: "Digicel Guyana", email: "ap@digicel.gy" },
+];
+
+export const SEED_ITEMS = [
+  // price is Decimal(10,2) in your schema
+  { name: "Standard VAT Widget", price: new Decimal(15000), tax: "VAT Standard 14%" },
+  { name: "Zero-rated Export Service", price: new Decimal(30000), tax: "Zero-rated 0%" },
+  { name: "Exempt Health Service", price: new Decimal(10000), tax: "Exempt" },
+  { name: "Standard VAT Gadget", price: new Decimal(8500), tax: "VAT Standard 14%" },
+  { name: "Standard VAT Subscription (Monthly)", price: new Decimal(5000), tax: "VAT Standard 14%" },
+];
+
+export const SEED_DOCS = {
+  invoices: [
+    {
+      number: 1001,
+      customer: "ACME Trading",
+      issueDate: "2025-08-01",
+      dueDate: "2025-08-15",
+      status: "sent",
+      lines: [
+        { item: "Standard VAT Widget", qty: 2 },
+        { item: "Zero-rated Export Service", qty: 1 },
+      ],
+      partialPayment: new Decimal(15000),
+    },
+    {
+      number: 1002,
+      customer: "Georgetown Retailers",
+      issueDate: "2025-08-05",
+      dueDate: "2025-08-20",
+      status: "draft",
+      lines: [{ item: "Standard VAT Gadget", qty: 5 }],
+    },
+  ],
+  estimates: [
+    {
+      number: "EST-2001",
+      customer: "New Amsterdam Hardware",
+      issueDate: "2025-08-10",
+      expiryDate: "2025-09-10",
+      status: "sent",
+      lines: [{ item: "Standard VAT Subscription (Monthly)", qty: 12 }],
+    },
+  ],
+  payments: [
+    // partial for INV-1001
+    {
+      ref: "PMT-9001",
+      invoiceNumber: 1001,
+      date: "2025-08-08",
+      amount: new Decimal(15000),
+      method: "Bank Transfer",
+      receiptNumber: 5001,
+    },
+  ],
+  bank: [
+    { ref: "BT-7001", date: "2025-08-02", description: "Opening Balance", amount: new Decimal(500000) },
+    { ref: "BT-7002", date: "2025-08-09", description: "Customer Payment - INV-1001", amount: new Decimal(15000) },
+    { ref: "BT-7003", date: "2025-08-12", description: "Rent", amount: new Decimal(-80000) },
+    { ref: "BT-7004", date: "2025-08-14", description: "Utilities", amount: new Decimal(-15000) },
+    { ref: "BT-7005", date: "2025-08-17", description: "Bank Fee", amount: new Decimal(-500) },
+  ],
+};
+


### PR DESCRIPTION
## Summary
- add reusable demo data for VAT codes, customers, vendors, items, docs
- implement idempotent seed runner that loads demo org and related data
- expose `pnpm seed:demo` script for easy demo seeding

## Testing
- `pnpm lint`
- `npx prisma generate`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bb811ff9a08329ba24888028b10c97