### PR TITLE
Implement demo enter/exit flow with cookies

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import TaxStrip from "@/components/marketing/TaxStrip";
 import LogosMarquee from "@/components/marketing/LogosMarquee";
 import FeatureCard from "@/components/marketing/FeatureCard";
+import DemoEnterButton from "@/components/marketing/DemoEnterButton";
 import { FileSpreadsheet, Receipt, Calculator, Banknote, ShieldCheck, PlugZap } from "lucide-react";
 
 export default function HomePage() {
@@ -22,6 +23,7 @@ export default function HomePage() {
             clean reports, and an API to plug into your dealer system.
           </p>
           <div className="mt-6 flex items-center justify-center gap-3">
+            <DemoEnterButton label="Try the demo" />
             <Button asChild size="lg">
               {/* Default to business for best fit */}
               <Link href="/sign-up?plan=business">Start free</Link>

--- a/src/app/api/demo/enter/route.ts
+++ b/src/app/api/demo/enter/route.ts
@@ -1,16 +1,25 @@
-import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
-import { purgeExpiredDemoDataIfAny, getDemoOrgId } from "@/lib/demo";
+import { auth } from "@/lib/auth";
+import { enterDemo, getOrCreateDemoOrgId } from "@/lib/demo";
+
+export async function GET() {
+  return NextResponse.json(
+    { error: "Use POST /api/demo/enter while authenticated." },
+    { status: 405 }
+  );
+}
 
 export async function POST() {
   const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ ok: false, error: "Not authenticated" }, { status: 401 });
+  if (!session?.user?.id) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  try {
+    const orgId = await getOrCreateDemoOrgId();
+    await enterDemo(orgId);
+    // You can redirect to dashboard for a nice UX
+    return NextResponse.json({ ok: true, orgId, redirect: "/dashboard" });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message ?? "demo enter failed" }, { status: 500 });
   }
-  await purgeExpiredDemoDataIfAny();
-  const orgId = await getDemoOrgId();
-  // @ts-ignore next-auth v5 session update
-  await session.update({ demo: true, orgId });
-  return NextResponse.json({ ok: true, orgId });
 }
 

--- a/src/app/api/demo/leave/route.ts
+++ b/src/app/api/demo/leave/route.ts
@@ -1,18 +1,19 @@
-import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
-import { purgeExpiredDemoDataIfAny } from "@/lib/demo";
+import { auth } from "@/lib/auth";
+import { leaveDemo } from "@/lib/demo";
+
+export async function GET() {
+  return NextResponse.json(
+    { error: "Use POST /api/demo/leave while authenticated." },
+    { status: 405 }
+  );
+}
 
 export async function POST() {
   const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ ok: false, error: "Not authenticated" }, { status: 401 });
-  }
-  // Opportunistic expired purge
-  await purgeExpiredDemoDataIfAny();
+  if (!session?.user?.id) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  // Unset demo and fall back to the user's last real org (kept in your own session.orgId handling)
-  // @ts-ignore
-  await session.update({ demo: false, orgId: null });
-  return NextResponse.json({ ok: true });
+  await leaveDemo();
+  return NextResponse.json({ ok: true, redirect: "/dashboard" });
 }
 

--- a/src/components/marketing/DemoEnterButton.tsx
+++ b/src/components/marketing/DemoEnterButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export default function DemoEnterButton({ label = "Try the demo" }: { label?: string }) {
+  const [pending, start] = useTransition();
+  const router = useRouter();
+
+  return (
+    <Button
+      size="lg"
+      onClick={() =>
+        start(async () => {
+          const res = await fetch("/api/demo/enter", { method: "POST" });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) {
+            alert(data?.error ?? "Could not enter demo");
+            return;
+          }
+          if (data?.redirect) router.push(data.redirect);
+          else router.refresh();
+        })
+      }
+      disabled={pending}
+    >
+      {pending ? "Entering…" : label}
+    </Button>
+  );
+}
+

--- a/src/components/topbar/DemoExitButton.tsx
+++ b/src/components/topbar/DemoExitButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+
+export default function DemoExitButton() {
+  const [pending, start] = useTransition();
+  const router = useRouter();
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() =>
+        start(async () => {
+          await fetch("/api/demo/leave", { method: "POST" });
+          router.push("/dashboard");
+          router.refresh();
+        })
+      }
+      disabled={pending}
+    >
+      Exit demo
+    </Button>
+  );
+}
+

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -1,28 +1,25 @@
 import ThemeToggle from "./ThemeToggle";
 import OrgSwitcher from "./OrgSwitcher";
 import UserMenu from "./UserMenu";
-import { auth } from "@/lib/auth";
-import { isDemoSession } from "@/lib/demo";
+import { isDemoModeFromCookies } from "@/lib/demo";
+import DemoExitButton from "./DemoExitButton";
 
 export default async function Topbar() {
-  const session = await auth();
-  const demo = await isDemoSession(session);
+  const inDemo = isDemoModeFromCookies();
 
   return (
     <header className="h-14 border-b bg-background/60 backdrop-blur flex items-center justify-between px-4">
-      <div className="text-sm text-muted-foreground">
+      <div className="flex items-center gap-2 text-sm">
         {/* breadcrumbs placeholder */}
+        {inDemo && (
+          <span className="px-2 py-0.5 rounded border text-xs bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+            Demo
+          </span>
+        )}
       </div>
       <div className="flex items-center gap-2">
-        {demo && (
-          <form action="/api/demo/leave" method="post" className="flex items-center gap-2 mr-2">
-            <span className="rounded-full bg-amber-100 text-amber-800 px-2 py-1 text-xs">
-              Demo company
-            </span>
-            <button className="text-xs underline">Leave demo &amp; clear my data</button>
-          </form>
-        )}
         <OrgSwitcher />
+        {inDemo ? <DemoExitButton /> : null}
         <ThemeToggle />
         <UserMenu />
       </div>


### PR DESCRIPTION
## Summary
- Support demo organization creation and membership and set demo/organization cookies
- Add endpoints to enter or leave demo and surface state in topbar
- Provide demo entry button on marketing page

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68bbb339828883298a9e7b32220966cd