### PR TITLE
Log demo activity and throttle demo enters

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -2,7 +2,9 @@ import Sidebar from "@/components/nav/Sidebar";
 import Topbar from "@/components/topbar/Topbar";
 import { ThemeProvider } from "@/components/ui/theme-provider";
 import { auth } from "@/lib/auth";
+import { isDemoModeFromCookies } from "@/lib/demo";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 
 export const metadata = {
   title: "heroBooks",
@@ -11,6 +13,7 @@ export const metadata = {
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const session = await auth();
   if (!session) redirect("/sign-in");
+  const inDemo = isDemoModeFromCookies();
 
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
@@ -18,6 +21,19 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         <Sidebar />
         <div className="flex-1 flex flex-col">
           <Topbar />
+          {inDemo && (
+            <div className="border-b bg-amber-50 text-amber-900 text-sm px-4 py-2">
+              You’re exploring the demo. Ready to go live?{" "}
+              <Link href="/pricing" className="underline">
+                Choose a plan
+              </Link>{" "}
+              or{" "}
+              <Link href="/checkout?plan=business" className="underline">
+                start Business
+              </Link>
+              .
+            </div>
+          )}
           <main className="p-6">{children}</main>
         </div>
       </div>

--- a/src/app/api/demo/leave/route.ts
+++ b/src/app/api/demo/leave/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { leaveDemo } from "@/lib/demo";
+import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   return NextResponse.json(
@@ -14,6 +15,16 @@ export async function POST() {
   if (!session?.user?.id) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
   await leaveDemo();
+  await prisma.auditLog.create({
+    data: {
+      actorId: session.user.id,
+      actorEmail: session.user.email ?? null,
+      action: "demo.leave",
+      targetType: "User",
+      targetId: session.user.id,
+      metadata: {},
+    },
+  });
   return NextResponse.json({ ok: true, redirect: "/dashboard" });
 }
 


### PR DESCRIPTION
## Summary
- log demo enter/leave events to AuditLog
- throttle repeated demo enters using a timestamp cookie
- show an upgrade banner when browsing the app in demo mode

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbb639c3e083299f27cb0bebb6e85f