### PR TITLE
feat: add onboarding paths and password reset

### DIFF
--- a/prisma/migrations/20250923000000_rev2_password_reset_tokens/migration.sql
+++ b/prisma/migrations/20250923000000_rev2_password_reset_tokens/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_token_key" ON "PasswordResetToken"("token");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_userId_token_idx" ON "PasswordResetToken"("userId", "token");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   sessions      Session[]
   memberships   UserOrg[]
   checkoutIntents CheckoutIntent[]
+  passwordResetTokens PasswordResetToken[]
   preference    UserPreference?
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @default(now()) @updatedAt
@@ -112,6 +113,18 @@ model VerificationToken {
   expires    DateTime
 
   @@id([identifier, token])
+}
+
+model PasswordResetToken {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  token     String   @unique
+  expiresAt DateTime
+  usedAt    DateTime?
+  createdAt DateTime @default(now())
+
+  @@index([userId, token])
 }
 
 model InboundMailbox {

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,41 @@
+export const metadata = { title: "Forgot Password — heroBooks" };
+
+export default function ForgotPasswordPage() {
+  return (
+    <section className="container mx-auto px-4 py-12 max-w-md">
+      <h1 className="text-2xl font-semibold">Forgot your password?</h1>
+      <p className="text-sm text-muted-foreground mt-1">
+        Enter your email and we’ll send you a reset link.
+      </p>
+      <form
+        className="mt-6 space-y-3"
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const f = new FormData(e.currentTarget as HTMLFormElement);
+          const email = String(f.get("email") || "");
+          const res = await fetch("/api/auth/password/reset/request", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email }),
+          });
+          if (res.ok) alert("If that email exists, we sent a reset link.");
+          else alert("Please try again in a moment.");
+        }}
+      >
+        <div className="grid gap-2">
+          <label className="text-sm">Email</label>
+          <input
+            name="email"
+            type="email"
+            required
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <button className="w-full rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium">
+          Send reset link
+        </button>
+        <p className="text-xs text-muted-foreground">We’ll email a link that expires in 30 minutes.</p>
+      </form>
+    </section>
+  );
+}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,65 @@
+export const metadata = { title: "Reset Password — heroBooks" };
+
+export default function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
+  const token =
+    (Array.isArray(searchParams?.token)
+      ? searchParams.token[0]
+      : searchParams?.token) ?? "";
+
+  return (
+    <section className="container mx-auto px-4 py-12 max-w-md">
+      <h1 className="text-2xl font-semibold">Set a new password</h1>
+      <form
+        className="mt-6 space-y-3"
+        onSubmit={async (e) => {
+          e.preventDefault();
+          const f = new FormData(e.currentTarget as HTMLFormElement);
+          const password = String(f.get("password") || "");
+          const confirm = String(f.get("confirm") || "");
+          if (password.length < 8)
+            return alert("Password must be at least 8 characters.");
+          if (password !== confirm)
+            return alert("Passwords do not match.");
+
+          const res = await fetch("/api/auth/password/reset/confirm", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token, password }),
+          });
+          if (res.ok) window.location.href = "/sign-in?reset=1";
+          else {
+            const j = await res.json().catch(() => ({}));
+            alert(j?.error ?? "Reset failed. Try requesting a new link.");
+          }
+        }}
+      >
+        <input type="hidden" name="token" value={token} />
+        <div className="grid gap-2">
+          <label className="text-sm">New password</label>
+          <input
+            name="password"
+            type="password"
+            required
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="grid gap-2">
+          <label className="text-sm">Confirm password</label>
+          <input
+            name="confirm"
+            type="password"
+            required
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+          />
+        </div>
+        <button className="w-full rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium">
+          Update password
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,21 +1,45 @@
 "use client";
 import { signIn } from "next-auth/react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
-export default function SignIn() {
+export default function SignIn({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const exists =
+    (Array.isArray(searchParams?.exists)
+      ? searchParams.exists[0]
+      : searchParams?.exists) === "1";
+  const reset =
+    (Array.isArray(searchParams?.reset)
+      ? searchParams.reset[0]
+      : searchParams?.reset) === "1";
 
   return (
     <main className="min-h-screen grid place-items-center px-6">
       <div className="w-full max-w-sm rounded-2xl border border-slate-800 p-6 bg-slate-900/40">
         <h1 className="text-xl font-semibold">Sign in</h1>
+        <p className="text-sm text-slate-400 mt-1">
+          New here? <a className="underline" href="/sign-up">Create an account</a>
+        </p>
+        {exists && (
+          <div className="mt-3 text-sm text-amber-600">
+            Account already exists — try signing in.
+          </div>
+        )}
+        {reset && (
+          <div className="mt-3 text-sm text-green-600">
+            Password updated. Please sign in.
+          </div>
+        )}
         <form
           className="mt-6 space-y-3"
           onSubmit={async (e) => {
@@ -35,9 +59,17 @@ export default function SignIn() {
         >
           <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
           <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
-          <Button className="w-full" type="submit">
-            Continue
-          </Button>
+          <div className="flex items-center justify-between">
+            <Button className="rounded-md px-4" type="submit">
+              Sign in
+            </Button>
+            <a
+              className="text-sm underline text-slate-400"
+              href="/forgot-password"
+            >
+              Forgot password?
+            </a>
+          </div>
           {error && <p className="text-sm text-red-500">{error}</p>}
         </form>
         <Button
@@ -47,9 +79,6 @@ export default function SignIn() {
         >
           Continue with Google
         </Button>
-        <p className="mt-4 text-xs text-slate-400">
-          No account? <Link href="/sign-up" className="underline">Sign up</Link>
-        </p>
       </div>
     </main>
   );

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -14,6 +14,10 @@ export default function SignUpPage({
     ? searchParams.plan[0]
     : searchParams?.plan ?? null;
   const initialPlan: Plan = normalizePlan(raw);
+  const demo =
+    (Array.isArray(searchParams?.demo)
+      ? searchParams.demo[0]
+      : searchParams?.demo) === "1";
 
   const [plan, setPlan] = useState<Plan>(initialPlan);
   const [email, setEmail] = useState("");
@@ -24,10 +28,10 @@ export default function SignUpPage({
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError("");
-    const res = await fetch("/api/register", {
+    const res = await fetch("/api/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password, plan }),
+      body: JSON.stringify({ email, password, plan, demo }),
     });
     const data = await res.json();
     if (!res.ok) {
@@ -37,6 +41,11 @@ export default function SignUpPage({
     const signInRes = await signIn("credentials", { email, password, redirect: false });
     if (signInRes?.error) {
       setError(signInRes.error);
+      return;
+    }
+    if (demo) {
+      await fetch("/api/demo/enter", { method: "POST" });
+      router.push("/dashboard");
       return;
     }
     alert("Account created!");
@@ -51,7 +60,8 @@ export default function SignUpPage({
     <section className="container mx-auto px-4 py-12 max-w-md">
       <h1 className="text-2xl font-semibold">Create your account</h1>
       <p className="text-sm text-muted-foreground mt-1">
-        Start with the plan that fits—change anytime.
+        Start with the plan that fits—change anytime.{' '}
+        <a className="underline" href="/sign-in">Already have an account? Sign in</a>
       </p>
 
       <form onSubmit={handleSubmit} className="mt-6 space-y-4">
@@ -73,6 +83,9 @@ export default function SignUpPage({
             ))}
           </div>
         </fieldset>
+
+        {/* Carry demo intent forward */}
+        {demo && <input type="hidden" name="demo" value="1" />}
 
         {/* Your existing fields */}
         <div className="grid gap-2">

--- a/src/app/(marketing)/get-started/page.tsx
+++ b/src/app/(marketing)/get-started/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export const metadata = { title: "Get Started — heroBooks" };
+
+export default function GetStartedPage() {
+  return (
+    <section className="container mx-auto px-4 py-12 max-w-3xl">
+      <h1 className="text-3xl font-semibold">Get started</h1>
+      <p className="text-muted-foreground mt-2">Choose how you’d like to begin.</p>
+
+      <div className="mt-8 grid gap-6 sm:grid-cols-2">
+        <div className="rounded-xl border bg-card p-6 flex flex-col">
+          <div className="text-lg font-medium">Create account</div>
+          <p className="text-sm text-muted-foreground mt-1">
+            Start fresh with your company file. You can invite your accountant any time.
+          </p>
+          <Button asChild className="mt-auto">
+            <Link href="/sign-up">Create account</Link>
+          </Button>
+        </div>
+
+        <div className="rounded-2xl border-2 border-primary bg-card p-6 flex flex-col">
+          <div className="text-lg font-medium">Explore demo</div>
+          <p className="text-sm text-muted-foreground mt-1">
+            See heroBooks with sample data. Requires a login so we can tailor help later.
+          </p>
+          {/* Preselect Business plan; add demo=1 so signup hands users into demo after registration */}
+          <Button asChild className="mt-auto">
+            <Link href="/sign-up?plan=business&demo=1">Try the demo</Link>
+          </Button>
+          <span className="text-xs text-muted-foreground mt-2">No credit card needed.</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,9 +1,7 @@
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import TaxStrip from "@/components/marketing/TaxStrip";
 import LogosMarquee from "@/components/marketing/LogosMarquee";
 import FeatureCard from "@/components/marketing/FeatureCard";
-import DemoEnterButton from "@/components/marketing/DemoEnterButton";
 import { FileSpreadsheet, Receipt, Calculator, Banknote, ShieldCheck, PlugZap } from "lucide-react";
 
 export default function HomePage() {
@@ -23,16 +21,19 @@ export default function HomePage() {
             clean reports, and an API to plug into your dealer system.
           </p>
           <div className="mt-6 flex items-center justify-center gap-3">
-            <DemoEnterButton label="Try the demo" />
-            <Button asChild size="lg">
-              {/* Default to business for best fit */}
-              <Link href="/sign-up?plan=business">Start free</Link>
-            </Button>
-            <Button asChild variant="outline" size="lg">
-              <Link href="/pricing">View pricing</Link>
-            </Button>
+            <a
+              href="/get-started"
+              className="inline-flex items-center rounded-md bg-primary text-primary-foreground h-10 px-6"
+            >
+              Get started
+            </a>
+            <a
+              href="/pricing"
+              className="inline-flex items-center rounded-md border h-10 px-6"
+            >
+              View pricing
+            </a>
           </div>
-          <div className="mt-6 text-xs text-muted-foreground">No credit card. Cancel anytime.</div>
         </div>
       </section>
 

--- a/src/app/api/auth/password/reset/confirm/route.ts
+++ b/src/app/api/auth/password/reset/confirm/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { redeemPasswordReset } from "@/lib/mail/password-reset";
+
+export async function POST(req: Request) {
+  const { token, password } = await req.json().catch(() => ({}));
+  if (!token || !password)
+    return NextResponse.json({ error: "invalid-payload" }, { status: 400 });
+
+  const hash = await bcrypt.hash(String(password), 10);
+  try {
+    await redeemPasswordReset(String(token), hash);
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message ?? "reset-failed" }, { status: 400 });
+  }
+}

--- a/src/app/api/auth/password/reset/request/route.ts
+++ b/src/app/api/auth/password/reset/request/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { issuePasswordReset } from "@/lib/mail/password-reset";
+
+export async function POST(req: Request) {
+  const { email } = await req.json().catch(() => ({}));
+  if (!email) return NextResponse.json({ error: "email-required" }, { status: 400 });
+
+  await issuePasswordReset(String(email));
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import bcrypt from "bcryptjs";
+
+export async function POST(req: Request) {
+  const { email, password } = await req.json();
+  if (!email || !password)
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+
+  const emailLower = String(email).trim().toLowerCase();
+  const existing = await prisma.user.findUnique({ where: { email: emailLower } });
+  if (existing) return NextResponse.json({ error: "Email exists" }, { status: 409 });
+
+  const passwordHash = await bcrypt.hash(String(password), 10);
+  await prisma.user.create({
+    data: { email: emailLower, passwordHash, name: emailLower.split("@")[0] },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/marketing/MarketingHeader.tsx
+++ b/src/components/marketing/MarketingHeader.tsx
@@ -48,7 +48,7 @@ export default function MarketingHeader() {
           )}
           {/* Preselect the popular plan on sign-up */}
           <Button asChild size="sm">
-            <Link href="/sign-up?plan=business">Get started</Link>
+            <Link href="/get-started">Get started</Link>
           </Button>
         </div>
       </div>

--- a/src/lib/mail/password-reset.ts
+++ b/src/lib/mail/password-reset.ts
@@ -1,0 +1,41 @@
+import crypto from "crypto";
+import { prisma } from "@/lib/prisma";
+import { sendMail } from "@/lib/mailer";
+
+export async function issuePasswordReset(email: string) {
+  const user = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
+  if (!user) return;
+
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + 1000 * 60 * 30); // 30 min
+
+  await prisma.passwordResetToken.create({
+    data: { userId: user.id, token, expiresAt },
+  });
+
+  const resetUrl = `${process.env.NEXTAUTH_URL}/reset-password?token=${token}`;
+  await sendMail({
+    to: email,
+    subject: "Reset your heroBooks password",
+    text: `Reset your password: ${resetUrl}`,
+    html: `<p>Reset your password:</p><p><a href="${resetUrl}">${resetUrl}</a></p><p>This link expires in 30 minutes.</p>`,
+  });
+}
+
+export async function redeemPasswordReset(token: string, newPasswordHash: string) {
+  const rec = await prisma.passwordResetToken.findUnique({ where: { token } });
+  if (!rec) throw new Error("Invalid or expired token");
+  if (rec.usedAt) throw new Error("Token already used");
+  if (rec.expiresAt < new Date()) throw new Error("Token expired");
+
+  await prisma.$transaction(async (tx) => {
+    await tx.user.update({
+      where: { id: rec.userId },
+      data: { passwordHash: newPasswordHash },
+    });
+    await tx.passwordResetToken.update({
+      where: { token },
+      data: { usedAt: new Date() },
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add get-started page linking to signup or demo
- wire signup/signin cross-links and demo auto-entry
- introduce password reset flow with tokens and email

## Testing
- `pnpm lint`
- `pnpm dlx prisma migrate dev -n "rev2_password_reset_tokens"` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbbba63748329bee8bbfe8769ad1d