### PR TITLE
fix auth forms and sanitize pricing redirect

### DIFF
--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
+import { getCsrfToken } from "next-auth/react";
 
-export default function SignInPage({
+export default async function SignInPage({
   searchParams,
 }: {
   searchParams: Record<string, string | string[] | undefined>;
@@ -14,6 +15,7 @@ export default function SignInPage({
 
   const showContinueDemo = reset || hadDemoBefore;
   const oauthCallback = showContinueDemo ? "/continue-demo" : "/dashboard";
+  const csrfToken = await getCsrfToken();
 
   return (
     <section className="container mx-auto px-4 py-12 max-w-md">
@@ -33,6 +35,7 @@ export default function SignInPage({
       )}
 
       <form action="/api/auth/callback/credentials" method="POST" className="mt-6 space-y-4">
+        <input type="hidden" name="csrfToken" value={csrfToken ?? undefined} />
         <div className="grid gap-2">
           <label className="text-sm">Email</label>
           <input name="email" type="email" required className="rounded-md border bg-background px-3 py-2 text-sm" placeholder="you@company.gy" />

--- a/src/app/(auth)/sign-up/SignUpForm.tsx
+++ b/src/app/(auth)/sign-up/SignUpForm.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+import type { Plan } from '@/lib/plans';
+
+export default function SignUpForm({ initialPlan, demo }: { initialPlan: Plan; demo: boolean }) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const form = new FormData(e.currentTarget);
+    const email = form.get('email');
+    const password = form.get('password');
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data?.error || 'Registration failed');
+        setLoading(false);
+        return;
+      }
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+      });
+      if (result?.error) {
+        setError(result.error);
+        setLoading(false);
+        return;
+      }
+      const nextUrl = demo
+        ? '/continue-demo'
+        : initialPlan === 'business'
+        ? '/checkout?plan=business'
+        : '/dashboard';
+      router.push(nextUrl);
+    } catch (e: any) {
+      setError('Registration failed');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+      <input type="hidden" name="plan" value={initialPlan} />
+      {demo && <input type="hidden" name="demo" value="1" />}
+      <div className="grid gap-2">
+        <label className="text-sm">Email</label>
+        <input
+          name="email"
+          type="email"
+          required
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+          placeholder="you@company.gy"
+        />
+      </div>
+      <div className="grid gap-2">
+        <label className="text-sm">Password</label>
+        <input
+          name="password"
+          type="password"
+          required
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+          placeholder="••••••••"
+        />
+      </div>
+      {error && <div className="text-sm text-red-600">{error}</div>}
+      <button
+        disabled={loading}
+        className="w-full rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium"
+      >
+        {loading ? 'Creating account…' : 'Create account'}
+      </button>
+      <p className="text-xs text-muted-foreground">
+        By creating an account, you agree to our <a className="underline" href="/legal/terms">Terms</a> and
+        <a className="underline" href="/legal/privacy">Privacy Policy</a>.
+      </p>
+    </form>
+  );
+}
+

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,16 +1,19 @@
-import Link from "next/link";
-import { normalizePlan, type Plan } from "@/lib/plans";
+'use client';
 
-export default function SignUpPage({ searchParams }: { searchParams: Record<string, string | string[] | undefined> }) {
-  const raw = Array.isArray(searchParams?.plan) ? searchParams.plan[0] : searchParams?.plan ?? null;
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import SignUpForm from './SignUpForm';
+import { normalizePlan, type Plan } from '@/lib/plans';
+
+export default function SignUpPage() {
+  const searchParams = useSearchParams();
+  const raw = searchParams.get('plan');
   const initialPlan: Plan = normalizePlan(raw);
-  const demo = (Array.isArray(searchParams?.demo) ? searchParams.demo[0] : searchParams?.demo) === "1";
+  const demo = searchParams.get('demo') === '1';
 
-  const planPretty = initialPlan === "starter" ? "Starter"
-    : initialPlan === "business" ? "Business"
-    : "Enterprise";
+  const planPretty =
+    initialPlan === 'starter' ? 'Starter' : initialPlan === 'business' ? 'Business' : 'Enterprise';
 
-  // Build "change plan" link back to pricing, preserving flow to come back here
   const changePlanHref = `/pricing?next=/sign-up&highlight=${initialPlan}`;
 
   return (
@@ -20,39 +23,21 @@ export default function SignUpPage({ searchParams }: { searchParams: Record<stri
         <div>
           Selected plan: <b>{planPretty}</b>
         </div>
-        <Link href={changePlanHref} className="underline text-muted-foreground">Change</Link>
+        <Link href={changePlanHref} className="underline text-muted-foreground">
+          Change
+        </Link>
       </div>
 
       <h1 className="text-2xl font-semibold mt-4">Create your account</h1>
       <p className="text-sm text-muted-foreground mt-1">
         Start with the plan that fits—change anytime.{" "}
-        <a className="underline" href="/sign-in">Already have an account? Sign in</a>
+        <a className="underline" href="/sign-in">
+          Already have an account? Sign in
+        </a>
       </p>
 
-      <form action="/api/auth/register" method="POST" className="mt-6 space-y-4">
-        {/* your existing plan radios (optional), fields, etc. */}
-        <input type="hidden" name="plan" value={initialPlan} />
-        {demo && <input type="hidden" name="demo" value="1" />}
-
-        {/* Email */}
-        <div className="grid gap-2">
-          <label className="text-sm">Email</label>
-          <input name="email" type="email" required className="rounded-md border bg-background px-3 py-2 text-sm" placeholder="you@company.gy" />
-        </div>
-        {/* Password */}
-        <div className="grid gap-2">
-          <label className="text-sm">Password</label>
-          <input name="password" type="password" required className="rounded-md border bg-background px-3 py-2 text-sm" placeholder="••••••••" />
-        </div>
-
-        <button className="w-full rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium">
-          Create account
-        </button>
-
-        <p className="text-xs text-muted-foreground">
-          By creating an account, you agree to our <a className="underline" href="/legal/terms">Terms</a> and <a className="underline" href="/legal/privacy">Privacy Policy</a>.
-        </p>
-      </form>
+      <SignUpForm initialPlan={initialPlan} demo={demo} />
     </section>
   );
 }
+

--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -10,7 +10,8 @@ function Row({ children }: { children: React.ReactNode }) {
 export const metadata = { title: "Pricing — heroBooks" };
 
 export default function PricingPage({ searchParams }: { searchParams: Record<string, string | string[] | undefined> }) {
-  const next = (Array.isArray(searchParams?.next) ? searchParams.next[0] : searchParams?.next) || "/sign-up";
+  const nextRaw = Array.isArray(searchParams?.next) ? searchParams.next[0] : searchParams?.next;
+  const next = typeof nextRaw === "string" && nextRaw.startsWith("/") ? nextRaw : "/sign-up";
   const highlightRaw = (Array.isArray(searchParams?.highlight) ? searchParams.highlight[0] : searchParams?.highlight) || "business";
   const highlight = (["starter", "business", "enterprise"].includes(highlightRaw) ? highlightRaw : "business") as PlanKey;
 

--- a/src/app/api/track/marketing/route.ts
+++ b/src/app/api/track/marketing/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { auth } from "@/lib/auth";
 
 /**
  * Track lightweight marketing clicks to AuditLog.
  * POST { event: "demo_click" | "compare_plans_click", meta?: Record<string, unknown> }
  */
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions);
+  const session = await auth();
   const { event, meta } = await req.json().catch(() => ({}));
   if (!event) return NextResponse.json({ error: "event-required" }, { status: 400 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts"
   ]
 }


### PR DESCRIPTION
## Summary
- add CSRF token to credentials sign-in form
- sanitize `next` param on pricing page
- restore sign-up flow with client-side register, login, and redirect
- use NextAuth `auth` helper in marketing tracking route

## Testing
- `pnpm lint`
- `pnpm build` *(fails: useSearchParams needs Suspense and event handlers passed to client component props)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcbcf976c8329bea7aa0656ebdc11