### PR TITLE
Add feature status helper and gated payroll access

### DIFF
--- a/src/app/(app)/payroll/page.tsx
+++ b/src/app/(app)/payroll/page.tsx
@@ -1,11 +1,17 @@
 "use client";
+import FeatureGuard from "@/components/feature/FeatureGuard";
 import { useState } from "react";
-import { Card } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 export default function PayrollPage() {
-  const [form, setForm] = useState({ employeeName: "", employeeEmail: "", period: "", gross: "" });
+  const [form, setForm] = useState({
+    employeeName: "",
+    employeeEmail: "",
+    period: "",
+    gross: "",
+  });
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<any>(null);
 
@@ -22,34 +28,62 @@ export default function PayrollPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <Card>
-        <div className="p-4 grid md:grid-cols-4 gap-3">
-          <Input placeholder="Employee name" value={form.employeeName} onChange={(e) => setForm({ ...form, employeeName: e.target.value })} />
-          <Input placeholder="Employee email (optional)" value={form.employeeEmail} onChange={(e) => setForm({ ...form, employeeEmail: e.target.value })} />
-          <Input type="month" placeholder="Period (YYYY-MM)" value={form.period} onChange={(e) => setForm({ ...form, period: e.target.value + "-01" })} />
-          <Input placeholder="Gross (GYD)" value={form.gross} onChange={(e) => setForm({ ...form, gross: e.target.value })} />
-          <div className="md:col-span-4">
-            <Button onClick={submit} disabled={busy || !form.employeeName || !form.period || !form.gross}>Create payslip</Button>
-          </div>
-        </div>
-      </Card>
-
-      {result && (
+    <FeatureGuard feature="payroll">
+      <div className="space-y-6">
         <Card>
-          <div className="p-4 space-y-2 text-sm">
-            <div><b>{result.employeeName}</b> — {new Date(result.period).toLocaleDateString()}</div>
-            <div>Gross: {result.gross}</div>
-            <div>Allowance: {result.allowance}</div>
-            <div>Chargeable: {result.chargeable}</div>
-            <div>PAYE: {result.payeTax}</div>
-            <div>NIS (Employee): {result.nisEmployee}</div>
-            <div>NIS (Employer): {result.nisEmployer}</div>
-            <div>Insurable: {result.nisInsurable}</div>
-            <div><b>Net:</b> {result.net}</div>
-          </div>
+          <CardContent className="p-4 grid md:grid-cols-4 gap-3">
+            <Input
+              placeholder="Employee name"
+              value={form.employeeName}
+              onChange={(e) => setForm({ ...form, employeeName: e.target.value })}
+            />
+            <Input
+              placeholder="Employee email (optional)"
+              value={form.employeeEmail}
+              onChange={(e) => setForm({ ...form, employeeEmail: e.target.value })}
+            />
+            <Input
+              type="month"
+              placeholder="Period (YYYY-MM)"
+              value={form.period}
+              onChange={(e) => setForm({ ...form, period: e.target.value + "-01" })}
+            />
+            <Input
+              placeholder="Gross (GYD)"
+              value={form.gross}
+              onChange={(e) => setForm({ ...form, gross: e.target.value })}
+            />
+            <div className="md:col-span-4">
+              <Button
+                onClick={submit}
+                disabled={busy || !form.employeeName || !form.period || !form.gross}
+              >
+                Create payslip
+              </Button>
+            </div>
+          </CardContent>
         </Card>
-      )}
-    </div>
+
+        {result && (
+          <Card>
+            <CardContent className="p-4 space-y-2 text-sm">
+              <div>
+                <b>{result.employeeName}</b> — {new Date(result.period).toLocaleDateString()}
+              </div>
+              <div>Gross: {result.gross}</div>
+              <div>Allowance: {result.allowance}</div>
+              <div>Chargeable: {result.chargeable}</div>
+              <div>PAYE: {result.payeTax}</div>
+              <div>NIS (Employee): {result.nisEmployee}</div>
+              <div>NIS (Employer): {result.nisEmployer}</div>
+              <div>Insurable: {result.nisInsurable}</div>
+              <div>
+                <b>Net:</b> {result.net}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </FeatureGuard>
   );
 }

--- a/src/app/(app)/reports/payroll/page.tsx
+++ b/src/app/(app)/reports/payroll/page.tsx
@@ -1,12 +1,19 @@
 "use client";
+import FeatureGuard from "@/components/feature/FeatureGuard";
 import { useEffect, useState } from "react";
-import { Card } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
 export default function PayrollReportPage() {
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
-  const [rows, setRows] = useState<{ month: string; gross: number; paye: number; nisEmp: number; nisEr: number }[]>([]);
+  const [rows, setRows] = useState<{
+    month: string;
+    gross: number;
+    paye: number;
+    nisEmp: number;
+    nisEr: number;
+  }[]>([]);
 
   async function load() {
     const qs = new URLSearchParams();
@@ -23,58 +30,63 @@ export default function PayrollReportPage() {
   }, []);
 
   return (
-    <div className="space-y-4">
-      <Card>
-        <div className="p-4 grid md:grid-cols-4 gap-3 items-end">
-          <div>
-            <div className="text-xs text-muted-foreground mb-1">From</div>
-            <Input type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
-          </div>
-          <div>
-            <div className="text-xs text-muted-foreground mb-1">To</div>
-            <Input type="date" value={to} onChange={(e) => setTo(e.target.value)} />
-          </div>
-          <div className="md:col-span-2">
-            <button className="px-3 py-2 rounded bg-primary text-primary-foreground" onClick={load}>
-              Run
-            </button>
-          </div>
-        </div>
-      </Card>
+    <FeatureGuard feature="payroll">
+      <div className="space-y-4">
+        <Card>
+          <CardContent className="p-4 grid md:grid-cols-4 gap-3 items-end">
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">From</div>
+              <Input type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">To</div>
+              <Input type="date" value={to} onChange={(e) => setTo(e.target.value)} />
+            </div>
+            <div className="md:col-span-2">
+              <button
+                className="px-3 py-2 rounded bg-primary text-primary-foreground"
+                onClick={load}
+              >
+                Run
+              </button>
+            </div>
+          </CardContent>
+        </Card>
 
-      <Card>
-        <div className="p-4">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-muted-foreground">
-                <th className="py-2">Month</th>
-                <th className="py-2">Gross</th>
-                <th className="py-2">PAYE</th>
-                <th className="py-2">NIS (Employee)</th>
-                <th className="py-2">NIS (Employer)</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((r) => (
-                <tr key={r.month} className="border-t">
-                  <td className="py-2">{r.month}</td>
-                  <td className="py-2">{r.gross.toFixed(2)}</td>
-                  <td className="py-2">{r.paye.toFixed(2)}</td>
-                  <td className="py-2">{r.nisEmp.toFixed(2)}</td>
-                  <td className="py-2">{r.nisEr.toFixed(2)}</td>
+        <Card>
+          <CardContent className="p-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-muted-foreground">
+                  <th className="py-2">Month</th>
+                  <th className="py-2">Gross</th>
+                  <th className="py-2">PAYE</th>
+                  <th className="py-2">NIS (Employee)</th>
+                  <th className="py-2">NIS (Employer)</th>
                 </tr>
-              ))}
-              {rows.length === 0 && (
-                <tr>
-                  <td className="py-6 text-center text-muted-foreground" colSpan={5}>
-                    No data
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </Card>
-    </div>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.month} className="border-t">
+                    <td className="py-2">{r.month}</td>
+                    <td className="py-2">{r.gross.toFixed(2)}</td>
+                    <td className="py-2">{r.paye.toFixed(2)}</td>
+                    <td className="py-2">{r.nisEmp.toFixed(2)}</td>
+                    <td className="py-2">{r.nisEr.toFixed(2)}</td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td className="py-6 text-center text-muted-foreground" colSpan={5}>
+                      No data
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      </div>
+    </FeatureGuard>
   );
 }

--- a/src/app/api/settings/feature-status/route.ts
+++ b/src/app/api/settings/feature-status/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getActiveOrgId, getFeatureStatus } from "@/lib/features";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const f = url.searchParams.get("f") as any;
+  const orgId = await getActiveOrgId();
+  const status = await getFeatureStatus(f, orgId);
+  return NextResponse.json({ ok: true, data: status });
+}

--- a/src/components/feature/FeatureGuard.tsx
+++ b/src/components/feature/FeatureGuard.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function FeatureGuard({
+  feature,
+  children,
+}: {
+  feature: string;
+  children: React.ReactNode;
+}) {
+  const [state, setState] = useState<
+    { allowed: boolean; reason: "ok" | "toggle" | "plan" | "super" } | null
+  >(null);
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch(
+        `/api/settings/feature-status?f=${encodeURIComponent(feature)}`,
+      );
+      const j = await res.json();
+      setState(j.data);
+    })();
+  }, [feature]);
+
+  if (!state) return null;
+  if (state.allowed) return <>{children}</>;
+
+  const heading = state.reason === "plan" ? "Upgrade required" : "Activation required";
+  const body =
+    state.reason === "plan"
+      ? "Your current plan does not include this feature. Upgrade to unlock it."
+      : "This feature is available on your plan but disabled. You can enable it in Settings.";
+
+  return (
+    <div className="max-w-lg space-y-2">
+      <div className="text-lg font-semibold">{heading}</div>
+      <div className="text-sm text-muted-foreground">{body}</div>
+      <div className="flex gap-2 pt-2">
+        {state.reason === "plan" ? (
+          <a
+            href="/pricing?highlight=business"
+            className="px-3 py-2 rounded bg-primary text-primary-foreground text-sm"
+          >
+            See plans
+          </a>
+        ) : (
+          <a
+            href="/settings/organization#taxes"
+            className="px-3 py-2 rounded bg-primary text-primary-foreground text-sm"
+          >
+            Enable in Settings
+          </a>
+        )}
+        <a href="/contact" className="px-3 py-2 rounded bg-muted text-sm">
+          Talk to us
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nav/Sidebar.tsx
+++ b/src/components/nav/Sidebar.tsx
@@ -1,11 +1,15 @@
 import Link from "next/link";
-import { canUseFeature, getActiveOrgId } from "@/lib/features";
+import { auth } from "@/lib/auth";
+import { getActiveOrgId, getFeatureStatuses } from "@/lib/features";
 
 export default async function Sidebar() {
+  const _session = await auth();
   const orgId = await getActiveOrgId();
-
-  const showPayroll = await canUseFeature("payroll", orgId);
-  const showPayrollReport = await canUseFeature("payroll", orgId);
+  const statuses = await getFeatureStatuses(["payroll"], orgId);
+  const payrollLocked = !statuses.payroll.allowed;
+  const badge = payrollLocked ? (
+    <span className="ml-2 text-[10px] rounded bg-muted px-1 py-0.5">Locked</span>
+  ) : null;
 
   return (
     <aside className="w-60 shrink-0 border-r bg-background p-3 text-sm">
@@ -17,7 +21,15 @@ export default async function Sidebar() {
         <NavItem href="/customers" label="Customers" />
         <NavItem href="/vendors" label="Vendors" />
         <NavItem href="/items" label="Products & Services" />
-        {showPayroll && <NavItem href="/payroll" label="Payroll" />}
+        <NavItem
+          href="/payroll"
+          label={
+            <>
+              <span>Payroll</span>
+              {badge}
+            </>
+          }
+        />
       </div>
 
       <div className="mt-4 space-y-1">
@@ -25,7 +37,15 @@ export default async function Sidebar() {
         <NavItem href="/reports/vat" label="VAT" />
         <NavItem href="/reports/trial-balance" label="Trial Balance" />
         <NavItem href="/reports/profit-loss" label="Profit & Loss" />
-        {showPayrollReport && <NavItem href="/reports/payroll" label="Payroll Summary" />}
+        <NavItem
+          href="/reports/payroll"
+          label={
+            <>
+              <span>Payroll Summary</span>
+              {badge}
+            </>
+          }
+        />
       </div>
 
       <div className="mt-4 space-y-1">
@@ -38,9 +58,12 @@ export default async function Sidebar() {
   );
 }
 
-function NavItem({ href, label }: { href: string; label: string }) {
+function NavItem({ href, label }: { href: string; label: React.ReactNode }) {
   return (
-    <Link href={href} className="block rounded px-2 py-1 hover:bg-accent hover:text-accent-foreground">
+    <Link
+      href={href}
+      className="flex items-center justify-between rounded px-2 py-1 hover:bg-accent hover:text-accent-foreground"
+    >
       {label}
     </Link>
   );

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,5 +1,18 @@
 import { cn } from "@/lib/utils";
 import React from "react";
+
 export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("rounded-2xl bg-slate-900/60 border border-slate-800 p-5", className)} {...props} />;
+  return (
+    <div
+      className={cn(
+        "rounded-2xl bg-slate-900/60 border border-slate-800 p-5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-4", className)} {...props} />;
 }


### PR DESCRIPTION
## Summary
- add FeatureGuard client wrapper and feature status API
- show payroll items in sidebar with Locked badge when unavailable
- gate payroll pages and report using FeatureGuard
- provide feature status helpers for plan/toggle checks

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Property 'taxAdvisory' does not exist on type 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68bbce4cd8808329a28d22b7bcd34ff5