### PR TITLE
Add locked feature tooltip and telemetry

### DIFF
--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -11,7 +11,10 @@ export const metadata = { title: "Pricing — heroBooks" };
 
 export default function PricingPage({ searchParams }: { searchParams: Record<string, string | string[] | undefined> }) {
   const nextRaw = Array.isArray(searchParams?.next) ? searchParams.next[0] : searchParams?.next;
-  const next = typeof nextRaw === "string" && nextRaw.startsWith("/") ? nextRaw : "/sign-up";
+  const next =
+    typeof nextRaw === "string" && nextRaw.startsWith("/") && !nextRaw.startsWith("//")
+      ? nextRaw
+      : "/sign-up";
   const highlightRaw = (Array.isArray(searchParams?.highlight) ? searchParams.highlight[0] : searchParams?.highlight) || "business";
   const highlight = (["starter", "business", "enterprise"].includes(highlightRaw) ? highlightRaw : "business") as PlanKey;
 

--- a/src/app/api/telemetry/feature-impression/route.ts
+++ b/src/app/api/telemetry/feature-impression/route.ts
@@ -1,0 +1,28 @@
+import { auth } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const session = await auth();
+  const userId = session?.user?.id || "anon";
+  const email = session?.user?.email || "";
+
+  const body = await req.json().catch(() => ({}));
+  const { feature, reason, path } = body as {
+    feature?: string;
+    reason?: string;
+    path?: string;
+  };
+
+  // For now, just log; you can later store to a table or send to an analytics sink.
+  console.log("telemetry:feature-impression", {
+    ts: new Date().toISOString(),
+    userId,
+    email,
+    feature,
+    reason,
+    path,
+  });
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/components/feature/FeatureGuard.tsx
+++ b/src/components/feature/FeatureGuard.tsx
@@ -19,6 +19,21 @@ export default function FeatureGuard({
       );
       const j = await res.json();
       setState(j.data);
+
+      // Telemetry: only when locked
+      if (j?.data && !j.data.allowed) {
+        try {
+          await fetch("/api/telemetry/feature-impression", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              feature,
+              reason: j.data.reason,
+              path: window.location.pathname,
+            }),
+          });
+        } catch {}
+      }
     })();
   }, [feature]);
 
@@ -29,7 +44,7 @@ export default function FeatureGuard({
   const body =
     state.reason === "plan"
       ? "Your current plan does not include this feature. Upgrade to unlock it."
-      : "This feature is available on your plan but disabled. You can enable it in Settings.";
+      : "This feature is available on your plan but disabled. You can enable it in Settings (tax and statutory settings may require additional inputs).";
 
   return (
     <div className="max-w-lg space-y-2">

--- a/src/components/nav/Sidebar.tsx
+++ b/src/components/nav/Sidebar.tsx
@@ -3,12 +3,27 @@ import { auth } from "@/lib/auth";
 import { getActiveOrgId, getFeatureStatuses } from "@/lib/features";
 
 export default async function Sidebar() {
-  const _session = await auth();
+  const session = await auth();
   const orgId = await getActiveOrgId();
   const statuses = await getFeatureStatuses(["payroll"], orgId);
-  const payrollLocked = !statuses.payroll.allowed;
-  const badge = payrollLocked ? (
-    <span className="ml-2 text-[10px] rounded bg-muted px-1 py-0.5">Locked</span>
+
+  const payroll = statuses.payroll;
+  const locked = !payroll.allowed;
+  const reasonText =
+    payroll.reason === "plan"
+      ? "Locked – Upgrade required"
+      : payroll.reason === "toggle"
+        ? "Locked – Enable in Settings"
+        : "Locked";
+
+  const badge = locked ? (
+    <span
+      className="ml-2 text-[10px] rounded bg-muted px-1 py-0.5"
+      title={reasonText}
+      aria-label={reasonText}
+    >
+      Locked
+    </span>
   ) : null;
 
   return (


### PR DESCRIPTION
## Summary
- show tooltip on locked payroll links explaining plan or toggle restrictions
- record feature-impression telemetry when users hit a locked feature
- reject protocol-relative URLs in pricing redirect

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing script? no output)*
- `pnpm build` *(fails: Property 'payslip' does not exist on type 'PrismaClient' in src/app/api/payroll/payslips/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd34b8f108329a4495ae006fc0321