### PR TITLE
Fix auth metadata and demo cookie handling

### DIFF
--- a/src/app/(auth)/forgot-password/layout.tsx
+++ b/src/app/(auth)/forgot-password/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Forgot Password — heroBooks",
+};
+
+export default function ForgotPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // No UI wrapper needed—just host metadata on the server side.
+  return children;
+}

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,47 +1,44 @@
 'use client';
-export const dynamic = 'force-dynamic';
 import { Suspense } from 'react';
-
-export const metadata = { title: "Forgot Password — heroBooks" };
 
 export default function ForgotPasswordPage() {
   return (
     <Suspense fallback={null}>
-    <section className="container mx-auto px-4 py-12 max-w-md">
-      <h1 className="text-2xl font-semibold">Forgot your password?</h1>
-      <p className="text-sm text-muted-foreground mt-1">
-        Enter your email and we’ll send you a reset link.
-      </p>
-      <form
-        className="mt-6 space-y-3"
-        onSubmit={async (e) => {
-          e.preventDefault();
-          const f = new FormData(e.currentTarget as HTMLFormElement);
-          const email = String(f.get("email") || "");
-          const res = await fetch("/api/auth/password/reset/request", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ email }),
-          });
-          if (res.ok) alert("If that email exists, we sent a reset link.");
-          else alert("Please try again in a moment.");
-        }}
-      >
-        <div className="grid gap-2">
-          <label className="text-sm">Email</label>
-          <input
-            name="email"
-            type="email"
-            required
-            className="rounded-md border bg-background px-3 py-2 text-sm"
-          />
-        </div>
-        <button className="w-full rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium">
-          Send reset link
-        </button>
-        <p className="text-xs text-muted-foreground">We’ll email a link that expires in 30 minutes.</p>
-      </form>
-    </section>
+        <section className="container mx-auto px-4 py-12 max-w-md">
+          <h1 className="text-2xl font-semibold">Forgot your password?</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Enter your email and we’ll send you a reset link.
+          </p>
+          <form
+            className="mt-6 space-y-3"
+            onSubmit={async (e) => {
+              e.preventDefault();
+              const f = new FormData(e.currentTarget as HTMLFormElement);
+              const email = String(f.get("email") || "");
+              const res = await fetch("/api/auth/password/reset/request", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ email }),
+              });
+              if (res.ok) alert("If that email exists, we sent a reset link.");
+              else alert("Please try again in a moment.");
+            }}
+          >
+            <div className="grid gap-2">
+              <label className="text-sm">Email</label>
+              <input
+                name="email"
+                type="email"
+                required
+                className="rounded-md border bg-background px-3 py-2 text-sm"
+              />
+            </div>
+            <button className="w-full rounded-md bg-primary text-primary-foreground py-2 text-sm font-medium">
+              Send reset link
+            </button>
+            <p className="text-xs text-muted-foreground">We’ll email a link that expires in 30 minutes.</p>
+          </form>
+        </section>
     </Suspense>
   );
 }

--- a/src/app/(auth)/sign-in/SignInClient.tsx
+++ b/src/app/(auth)/sign-in/SignInClient.tsx
@@ -1,0 +1,109 @@
+'use client';
+import { useEffect, useState } from "react";
+import { getCsrfToken } from "next-auth/react";
+
+export default function SignInClient({
+  hadDemoBefore,
+  reset,
+  exists,
+}: {
+  hadDemoBefore: boolean;
+  reset: boolean;
+  exists?: boolean;
+}) {
+  const [csrfToken, setCsrfToken] = useState<string | undefined>(undefined);
+  const [showContinueDemo, setShowContinueDemo] = useState<boolean>(false);
+
+  useEffect(() => {
+    getCsrfToken().then((token) => setCsrfToken(token ?? undefined));
+    // Server already told us if demo cookies exist (httpOnly).
+    setShowContinueDemo(reset || hadDemoBefore);
+  }, [hadDemoBefore, reset]);
+
+  const oauthCallback = showContinueDemo ? "/continue-demo" : "/dashboard";
+
+  return (
+    <section className="container mx-auto px-4 py-12 max-w-md">
+      <h1 className="text-2xl font-semibold">Sign in</h1>
+      <p className="text-sm text-muted-foreground mt-1">
+        New here? <a className="underline" href="/sign-up">Create an account</a>
+      </p>
+      {exists && (
+        <div className="mt-3 text-sm text-amber-600">
+          Account already exists — try signing in.
+        </div>
+      )}
+
+      {showContinueDemo && (
+        <div className="mt-4 flex items-center gap-2 text-xs">
+          <span className="rounded-full border px-2 py-1 bg-amber-50 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
+            Continue demo
+          </span>
+          <span className="text-muted-foreground">
+            After sign-in, we’ll drop you back into the demo.
+          </span>
+        </div>
+      )}
+
+      <form action="/api/auth/callback/credentials" method="POST" className="mt-6 space-y-4">
+        <input type="hidden" name="csrfToken" value={csrfToken} />
+        <div className="grid gap-2">
+          <label className="text-sm">Email</label>
+          <input
+            name="email"
+            type="email"
+            required
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="you@company.gy"
+          />
+        </div>
+        <div className="grid gap-2">
+          <label className="text-sm">Password</label>
+          <input
+            name="password"
+            type="password"
+            required
+            className="rounded-md border bg-background px-3 py-2 text-sm"
+            placeholder="••••••••"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <button className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm">
+            Sign in
+          </button>
+
+          {showContinueDemo && (
+            <button
+              type="submit"
+              formAction="/api/auth/callback/credentials?callbackUrl=/continue-demo"
+              className="rounded-md border px-4 py-2 text-sm"
+              title="Sign in and return to demo"
+            >
+              Sign in & continue demo
+            </button>
+          )}
+
+          <a className="text-sm underline text-muted-foreground" href="/forgot-password">
+            Forgot password?
+          </a>
+        </div>
+      </form>
+
+      {/* Google OAuth with callbackUrl respecting Continue demo */}
+      <div className="mt-6">
+        <a
+          className="inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm w-full"
+          href={`/api/auth/signin/google?callbackUrl=${encodeURIComponent(oauthCallback)}`}
+          title={
+            showContinueDemo
+              ? 'Sign in with Google & continue demo'
+              : 'Sign in with Google'
+          }
+        >
+          Continue with Google
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,96 +1,17 @@
-'use client';
-export const dynamic = 'force-dynamic';
-import { Suspense, useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { getCsrfToken } from 'next-auth/react';
+import { cookies } from "next/headers";
+import SignInClient from "./SignInClient";
 
-export default function SignInPage() {
-  const searchParams = useSearchParams();
-  const exists = searchParams.get('exists') === '1';
-  const reset = searchParams.get('reset') === '1';
-
-  const [csrfToken, setCsrfToken] = useState<string | undefined>();
-  const [showContinueDemo, setShowContinueDemo] = useState(false);
-
-  useEffect(() => {
-    getCsrfToken().then((token) => setCsrfToken(token ?? undefined));
-    const getCookie = (name: string) =>
-      document.cookie
-        .split('; ')
-        .find((row) => row.startsWith(name + '='))?.split('=')[1];
-    const hadDemoBefore =
-      getCookie('hb_demo') === '1' || Boolean(getCookie('hb_demo_last'));
-    setShowContinueDemo(reset || hadDemoBefore);
-  }, [reset]);
-
-  const oauthCallback = showContinueDemo ? '/continue-demo' : '/dashboard';
-
+export default function SignInPage({
+  searchParams,
+}: {
+  searchParams?: { exists?: string; reset?: string };
+}) {
+  const c = cookies();
+  const hadDemoBefore =
+    c.get("hb_demo")?.value === "1" || Boolean(c.get("hb_demo_last")?.value);
+  const reset = searchParams?.reset === "1";
+  const exists = searchParams?.exists === "1";
   return (
-    <Suspense fallback={null}>
-      <section className="container mx-auto px-4 py-12 max-w-md">
-        <h1 className="text-2xl font-semibold">Sign in</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          New here? <a className="underline" href="/sign-up">Create an account</a>
-        </p>
-        {exists && (
-          <div className="mt-3 text-sm text-amber-600">
-            Account already exists — try signing in.
-          </div>
-        )}
-
-        {showContinueDemo && (
-          <div className="mt-4 flex items-center gap-2 text-xs">
-            <span className="rounded-full border px-2 py-1 bg-amber-50 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
-              Continue demo
-            </span>
-            <span className="text-muted-foreground">
-              After sign-in, we’ll drop you back into the demo.
-            </span>
-          </div>
-        )}
-
-        <form action="/api/auth/callback/credentials" method="POST" className="mt-6 space-y-4">
-          <input type="hidden" name="csrfToken" value={csrfToken} />
-          <div className="grid gap-2">
-            <label className="text-sm">Email</label>
-            <input name="email" type="email" required className="rounded-md border bg-background px-3 py-2 text-sm" placeholder="you@company.gy" />
-          </div>
-          <div className="grid gap-2">
-            <label className="text-sm">Password</label>
-            <input name="password" type="password" required className="rounded-md border bg-background px-3 py-2 text-sm" placeholder="••••••••" />
-          </div>
-
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <button className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm">Sign in</button>
-
-            {showContinueDemo && (
-              <button
-                type="submit"
-                formAction="/api/auth/callback/credentials?callbackUrl=/continue-demo"
-                className="rounded-md border px-4 py-2 text-sm"
-                title="Sign in and return to demo"
-              >
-                Sign in & continue demo
-              </button>
-            )}
-
-            <a className="text-sm underline text-muted-foreground" href="/forgot-password">
-              Forgot password?
-            </a>
-          </div>
-        </form>
-
-        {/* Google OAuth with callbackUrl respecting Continue demo */}
-        <div className="mt-6">
-          <a
-            className="inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm w-full"
-            href={`/api/auth/signin/google?callbackUrl=${encodeURIComponent(oauthCallback)}`}
-            title={showContinueDemo ? 'Sign in with Google & continue demo' : 'Sign in with Google'}
-          >
-            Continue with Google
-          </a>
-        </div>
-      </section>
-    </Suspense>
+    <SignInClient hadDemoBefore={hadDemoBefore} reset={reset} exists={exists} />
   );
 }


### PR DESCRIPTION
## Summary
- move forgot-password metadata to server layout so page can stay client-only
- read demo cookies server-side on sign-in and pass flags to a new client component

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbe1bedc248329963cc628f95f8100