### PR TITLE
Allow admin analytics access and harden sidebar badge

### DIFF
--- a/src/app/api/admin/analytics/overview/route.ts
+++ b/src/app/api/admin/analytics/overview/route.ts
@@ -3,14 +3,28 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import { isSuperUser } from "@/lib/features";
 
+async function isAdmin(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  });
+  const role = user?.role?.toLowerCase();
+  return role === "admin" || role === "superadmin";
+}
+
 function ymd(d: Date) {
   return d.toISOString().slice(0, 10);
 }
 
 export async function GET() {
   const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+  }
   const superOk = await isSuperUser();
-  if (!session?.user?.id || !superOk) {
+  const adminOk = await isAdmin(userId);
+  if (!superOk && !adminOk) {
     return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/components/nav/LockedBadge.tsx
+++ b/src/components/nav/LockedBadge.tsx
@@ -1,0 +1,5 @@
+export default function LockedBadge({ reason }: { reason: string }) {
+  return (
+    <span className="ml-2 text-xs text-muted-foreground">{reason}</span>
+  );
+}

--- a/src/components/nav/Sidebar.tsx
+++ b/src/components/nav/Sidebar.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import LockedBadge from "./LockedBadge";
 import {
   LayoutDashboard,
   FileText,
@@ -72,6 +75,8 @@ export default function Sidebar() {
                 const active =
                   pathname === item.href || pathname?.startsWith(item.href + "/");
                 const Icon = item.icon;
+                const locked = false;
+                const reason: string | undefined = undefined;
                 return (
                   <li key={item.href}>
                     <Link
@@ -83,6 +88,7 @@ export default function Sidebar() {
                     >
                       <Icon className="h-4 w-4" />
                       {item.label}
+                      {locked && <LockedBadge reason={reason ?? "Locked"} />}
                     </Link>
                   </li>
                 );


### PR DESCRIPTION
## Summary
- allow regular admins to access `/api/admin/analytics/overview`
- add LockedBadge with default reason to prevent undefined in sidebar

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Error occurred prerendering page "/sign-up")*

------
https://chatgpt.com/codex/tasks/task_e_68bbe66917448329a578ac76e5b1a565