### PR TITLE
Add dashboard plan hint and correct admin role check

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import AdminDashboard from "@/components/dashboard/AdminDashboard";
 import UserDashboard from "@/components/dashboard/UserDashboard";
+import PlanHint from "@/components/dashboard/PlanHint";
 
 export default async function DashboardPage() {
   const session = await auth();
@@ -8,6 +9,17 @@ export default async function DashboardPage() {
   const isSuper = (process.env.SUPERUSER_EMAILS || "")
     .toLowerCase()
     .includes((session?.user?.email || "").toLowerCase());
-  if (isSuper || role === "ADMIN") return <AdminDashboard />;
-  return <UserDashboard />;
+  if (isSuper || role === "ADMIN")
+    return (
+      <section className="p-6 space-y-6">
+        <PlanHint />
+        <AdminDashboard />
+      </section>
+    );
+  return (
+    <section className="p-6 space-y-6">
+      <PlanHint />
+      <UserDashboard />
+    </section>
+  );
 }

--- a/src/app/api/admin/analytics/overview/route.ts
+++ b/src/app/api/admin/analytics/overview/route.ts
@@ -4,12 +4,11 @@ import { auth } from "@/lib/auth";
 import { isSuperUser } from "@/lib/features";
 
 async function isAdmin(userId: string) {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { role: true },
+  const membership = await prisma.userOrg.findFirst({
+    where: { userId, role: { in: ["OWNER", "ADMIN"] } },
+    select: { id: true },
   });
-  const role = user?.role?.toLowerCase();
-  return role === "admin" || role === "superadmin";
+  return Boolean(membership);
 }
 
 function ymd(d: Date) {

--- a/src/components/dashboard/PlanHint.tsx
+++ b/src/components/dashboard/PlanHint.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { getCurrentPlanForActiveOrg } from "@/lib/subscriptions/current-plan";
+import UpgradeCta from "./UpgradeCta";
+
+export default async function PlanHint() {
+  const plan = await getCurrentPlanForActiveOrg();
+  const isStarter =
+    plan === "starter" || plan === "none" || plan === "pending_assignment";
+
+  if (isStarter) {
+    return (
+      <div className="rounded-xl border bg-emerald-50 text-emerald-900 dark:bg-emerald-900/20 dark:text-emerald-200 p-4 flex items-start gap-3">
+        <div className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-600 text-white text-xs">
+          ✓
+        </div>
+        <div className="text-sm">
+          <div className="font-medium">
+            Upgrade to unlock VAT automation & Bank Reconcile
+          </div>
+          <div className="text-emerald-900/80 dark:text-emerald-200/80">
+            Business includes PAYE/NIS summaries, custom branding, and
+            priority support.
+          </div>
+        </div>
+        <div className="ml-auto">
+          <UpgradeCta />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border bg-muted/40 p-4 text-sm flex items-start gap-3">
+      <div className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full border text-xs">i</div>
+      <div>
+        <div className="font-medium">Most features are free on Starter</div>
+        <div className="text-muted-foreground">
+          Compare plans anytime — you’re on <b>{plan}</b>.
+        </div>
+      </div>
+      <div className="ml-auto">
+        <Link
+          href="/pricing?highlight=business"
+          className="inline-flex items-center rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+        >
+          View pricing
+        </Link>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/UpgradeCta.tsx
+++ b/src/components/dashboard/UpgradeCta.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+export default function UpgradeCta() {
+  return (
+    <a
+      href="/pricing?next=/checkout&highlight=business"
+      onClick={() => {
+        fetch("/api/track/marketing", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            event: "upgrade_cta_click",
+            meta: { source: "dashboard_hint" },
+          }),
+          keepalive: true,
+        });
+      }}
+      className="inline-flex items-center rounded-md bg-emerald-600 text-white px-3 py-1.5 text-sm hover:bg-emerald-700"
+    >
+      Upgrade
+    </a>
+  );
+}
+


### PR DESCRIPTION
## Summary
- show upgrade hint on dashboard with pricing links
- track upgrade CTA clicks for marketing analytics
- fix admin analytics endpoint to respect org-level roles

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bbe87de2948329a6e76f82465baf1e