### PR TITLE
Restore focus color and enable marketing click tracking

### DIFF
--- a/src/components/app/AppBannerRandom.tsx
+++ b/src/components/app/AppBannerRandom.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { chooseOnce } from "@/lib/randomize";
+import TrackLink from "@/components/marketing/TrackLink";
 
 const BANNERS = [
   { text: "Invite your accountant — it’s free to add users.", href: "/settings/team", color: "bg-blue-50 text-blue-900", event: "banner_invite_accountant" },
@@ -15,20 +15,14 @@ export default function AppBannerRandom() {
     <div className={`px-4 py-2 border-b ${b.color}`}>
       <div className="container mx-auto flex items-center justify-between text-sm">
         <span>{b.text}</span>
-        <Link
+        <TrackLink
           href={b.href}
           className="underline font-medium ml-4"
-          onClick={() => {
-            fetch("/api/track/marketing", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ event: b.event, meta: { where: "app_banner" } }),
-              keepalive: true,
-            });
-          }}
+          event={b.event}
+          meta={{ where: "app_banner" }}
         >
           Learn more
-        </Link>
+        </TrackLink>
       </div>
     </div>
   );

--- a/src/components/marketing/HeroRandom.tsx
+++ b/src/components/marketing/HeroRandom.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { chooseOnce } from "@/lib/randomize";
+import TrackLink from "@/components/marketing/TrackLink";
 
 const HERO_IMAGES = [
   "/photos/landing/construction.webp",
@@ -26,34 +27,22 @@ export default function HeroRandom() {
           Local compliance, faster invoices, clean reports, and an API when you’re ready.
         </p>
         <div className="mt-6 flex items-center gap-3">
-          <a
+          <TrackLink
             href="/get-started"
             className="inline-flex h-10 items-center rounded-md bg-primary px-6 text-primary-foreground"
-            onClick={() =>
-              fetch("/api/track/marketing", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ event: "cta_get_started", meta: { hero: chosen } }),
-                keepalive: true,
-              })
-            }
+            event="cta_get_started"
+            meta={{ hero: chosen }}
           >
             Get started
-          </a>
-          <a
+          </TrackLink>
+          <TrackLink
             href="/sign-up?plan=business&demo=1"
             className="inline-flex h-10 items-center rounded-md border px-6"
-            onClick={() =>
-              fetch("/api/track/marketing", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ event: "cta_try_demo", meta: { hero: chosen } }),
-                keepalive: true,
-              })
-            }
+            event="cta_try_demo"
+            meta={{ hero: chosen }}
           >
             Try demo
-          </a>
+          </TrackLink>
         </div>
       </div>
 

--- a/src/components/marketing/TipsAdsRandom.tsx
+++ b/src/components/marketing/TipsAdsRandom.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { chooseOnce } from "@/lib/randomize";
+import TrackLink from "@/components/marketing/TrackLink";
 
 const CARDS = [
   { title: "Try the demo", text: "See sample data with VAT-ready invoices.", href: "/sign-up?plan=business&demo=1", event: "tip_try_demo" },
@@ -14,20 +14,14 @@ export default function TipsAdsRandom() {
       <div className="rounded-2xl border p-6 bg-primary/5">
         <div className="text-lg font-medium">{c.title}</div>
         <p className="text-sm text-muted-foreground mt-2">{c.text}</p>
-        <Link
+        <TrackLink
           href={c.href}
           className="inline-flex mt-4 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
-          onClick={() =>
-            fetch("/api/track/marketing", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ event: c.event, meta: { where: "tips_ads" } }),
-              keepalive: true,
-            })
-          }
+          event={c.event}
+          meta={{ where: "tips_ads" }}
         >
           Learn more
-        </Link>
+        </TrackLink>
       </div>
     </section>
   );

--- a/src/components/marketing/TrackLink.tsx
+++ b/src/components/marketing/TrackLink.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 
 type Props = React.ComponentProps<typeof Link> & {
-  event: "demo_click" | "compare_plans_click";
+  event: string;
   meta?: Record<string, unknown>;
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,6 +40,10 @@ const config: Config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        brand: {
+          DEFAULT: "hsl(var(--primary))",
+          accent: "hsl(var(--accent))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- add brand color alias so `focus:border-brand` utilities are generated
- hook marketing banners and CTAs through TrackLink for analytics

## Testing
- `pnpm lint`
- `pnpm build` *(fails: getServerSession not exported; missing tailwindcss-animate)*

------
https://chatgpt.com/codex/tasks/task_e_68bc848eb30c8329860d2b73b1b5d68a