### PR TITLE
fix: use auth helper in marketing tracker

### DIFF
--- a/src/app/api/track/marketing/route.ts
+++ b/src/app/api/track/marketing/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { auth } from "@/lib/auth";
 
 /** POST { event: string; meta?: Record<string, unknown> } */
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions);
+  const session = await auth();
   const { event, meta } = await req.json().catch(() => ({}));
   if (!event) return NextResponse.json({ error: "event-required" }, { status: 400 });
 


### PR DESCRIPTION
## Summary
- replace `getServerSession` with App Router-friendly `auth` helper
- reinstall dependencies to ensure Tailwind CSS animate plugin present

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc8856d47483298f1280fc335adc62