### PR TITLE
feat: move marketing cookies to middleware

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -2,10 +2,15 @@ import HeroRandom from "@/components/marketing/HeroRandom";
 import FeaturesRandom from "@/components/marketing/FeaturesRandom";
 import TestimonialsRandom from "@/components/marketing/TestimonialsRandom";
 import TipsAdsRandom from "@/components/marketing/TipsAdsRandom";
+import { cookies } from "next/headers";
 
 export default function MarketingHome() {
+  const variant = cookies().get("hb_variant")?.value ?? null;
   return (
-    <main className="container mx-auto px-4 py-12">
+    <main
+      className="container mx-auto px-4 py-12"
+      data-variant={variant ?? undefined}
+    >
       <HeroRandom />
       <FeaturesRandom count={6} />
       <section id="why-local" className="mt-16 rounded-2xl border bg-primary/5 p-6">

--- a/src/app/api/marketing/cookie/route.ts
+++ b/src/app/api/marketing/cookie/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const { name, value, maxAge } = await req.json();
+  if (!name || typeof value !== "string") {
+    return NextResponse.json(
+      { ok: false, error: "Invalid payload" },
+      { status: 400 }
+    );
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(name, value, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: true,
+    maxAge: typeof maxAge === "number" ? maxAge : 60 * 60 * 24 * 365,
+  });
+  return res;
+}

--- a/src/lib/randomize.ts
+++ b/src/lib/randomize.ts
@@ -1,49 +1,45 @@
 import { cookies, headers } from "next/headers";
 
 /**
- * Choose one item from a pool and persist in a readable cookie for ~12h.
+ * Choose one item from a pool based on a stored cookie value.
+ * If the cookie is absent or invalid, choose randomly without persisting.
  */
 export function chooseOnce<T>(cookieName: string, pool: T[]): T {
   headers(); // ensure dynamic segment
   const jar = cookies();
-  let idx = Number(jar.get(cookieName)?.value ?? NaN);
-  if (Number.isNaN(idx) || idx < 0 || idx >= pool.length) {
-    idx = Math.floor(Math.random() * pool.length);
-    jar.set(cookieName, String(idx), { path: "/", httpOnly: false, sameSite: "lax", maxAge: 60 * 60 * 12 });
+  const idx = Number(jar.get(cookieName)?.value ?? NaN);
+  if (!Number.isNaN(idx) && idx >= 0 && idx < pool.length) {
+    return pool[idx];
   }
-  return pool[idx];
+  return pool[Math.floor(Math.random() * pool.length)];
 }
 
 /**
- * Choose N unique items from a pool and persist their indices for ~12h.
+ * Choose N unique items from a pool based on stored cookie indices.
+ * If the cookie is absent or invalid, choose randomly without persisting.
  */
 export function chooseNOnce<T>(cookieName: string, pool: T[], n: number): T[] {
   headers(); // ensure dynamic segment
   const jar = cookies();
   const raw = jar.get(cookieName)?.value;
-  let pickedIdx: number[] | null = null;
-
   if (raw) {
     try {
       const arr = JSON.parse(raw) as number[];
       if (Array.isArray(arr) && arr.every((x) => Number.isInteger(x) && x >= 0 && x < pool.length)) {
-        pickedIdx = arr.slice(0, n);
+        return arr.slice(0, n).map((i) => pool[i]);
       }
     } catch {
       /* ignore */
     }
   }
 
-  if (!pickedIdx || pickedIdx.length !== n) {
-    const all = [...pool.keys()];
-    // Fisher-Yates for first n
-    for (let i = all.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [all[i], all[j]] = [all[j], all[i]];
-    }
-    pickedIdx = all.slice(0, Math.min(n, pool.length));
-    jar.set(cookieName, JSON.stringify(pickedIdx), { path: "/", httpOnly: false, sameSite: "lax", maxAge: 60 * 60 * 12 });
+  const all = [...pool.keys()];
+  // Fisher-Yates for first n
+  for (let i = all.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [all[i], all[j]] = [all[j], all[i]];
   }
-
-  return pickedIdx.map((i) => pool[i]);
+  return all
+    .slice(0, Math.min(n, pool.length))
+    .map((i) => pool[i]);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,46 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+function randomVariant() {
+  return Math.random() < 0.5 ? "A" : "B";
+}
+
 export function middleware(req: NextRequest) {
-  // Protect (app) area from being statically cached; enforce auth via page logic.
-  return NextResponse.next();
+  const res = NextResponse.next();
+
+  const { pathname } = req.nextUrl;
+  const isMarketingRoute =
+    pathname === "/" ||
+    pathname.startsWith("/pricing") ||
+    pathname.startsWith("/about") ||
+    pathname.startsWith("/contact") ||
+    pathname.startsWith("/get-started") ||
+    pathname.startsWith("/help") ||
+    pathname.startsWith("/legal");
+
+  if (!isMarketingRoute) return res;
+
+  if (!req.cookies.get("hb_variant")) {
+    res.cookies.set("hb_variant", randomVariant(), {
+      path: "/",
+      httpOnly: true,
+      sameSite: "lax",
+      secure: true,
+      maxAge: 60 * 60 * 24 * 365,
+    });
+  }
+
+  return res;
 }
 
 export const config = {
-  matcher: ["/((?!_next|api/auth|sign-in|sign-up|favicon.ico).*)"],
+  matcher: [
+    "/",
+    "/pricing",
+    "/about",
+    "/contact",
+    "/get-started",
+    "/help",
+    "/legal/:path*",
+  ],
 };


### PR DESCRIPTION
## Summary
- read A/B cookie instead of writing during render on marketing page
- seed `hb_variant` cookie for marketing routes via middleware
- expose `/api/marketing/cookie` route for client-side cookie writes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcb534c5f883299268e6d0d3303490