### PR TITLE
Restrict marketing cookie API

### DIFF
--- a/src/app/api/marketing/cookie/route.ts
+++ b/src/app/api/marketing/cookie/route.ts
@@ -1,8 +1,25 @@
 import { NextResponse } from "next/server";
 
+const ALLOWED_COOKIE_NAMES = ["marketing_consent"];
+
+function sameOrigin(req: Request): boolean {
+  const origin = req.headers.get("origin");
+  if (!origin) return false;
+  try {
+    const { host } = new URL(req.url);
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
 export async function POST(req: Request) {
+  if (!sameOrigin(req)) {
+    return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+  }
+
   const { name, value, maxAge } = await req.json();
-  if (!name || typeof value !== "string") {
+  if (!ALLOWED_COOKIE_NAMES.includes(name) || typeof value !== "string") {
     return NextResponse.json(
       { ok: false, error: "Invalid payload" },
       { status: 400 }


### PR DESCRIPTION
## Summary
- ensure marketing cookie endpoint only accepts requests from same origin
- only allow setting the `marketing_consent` cookie

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bcca65c8648329b6460d31ea335da7