### PR TITLE
feat: add mobile menu and search

### DIFF
--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -1,12 +1,9 @@
 export const metadata = { title: "About heroBooks" };
-
 export default function AboutPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
       <h1 className="text-3xl font-bold">About heroBooks</h1>
-      <p className="mt-4 text-muted-foreground">
-        We build modern, local-first accounting tools tailored for Guyanese businesses.
-      </p>
+      <p className="mt-4 text-muted-foreground">We build modern, local-first accounting tools tailored for Guyanese businesses.</p>
     </div>
   );
 }

--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -1,5 +1,4 @@
 export const metadata = { title: "Talk to us — heroBooks" };
-
 export default function ContactPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">

--- a/src/app/(marketing)/legal/page.tsx
+++ b/src/app/(marketing)/legal/page.tsx
@@ -1,5 +1,4 @@
 export const metadata = { title: "Terms & Privacy — heroBooks" };
-
 export default function LegalPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,7 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
+import { recordFeatureImpression } from "@/lib/telemetry";
 
 export default function HomePage() {
+  const onPriceClick = (plan: string) => () =>
+    recordFeatureImpression({ feature: "cta_click", reason: `pricing:${plan}`, path: "/#pricing" });
+
   return (
     <div>
       {/* HERO */}
@@ -15,12 +19,29 @@ export default function HomePage() {
               VAT-ready invoices, clean reports, and an API ready to plug into your dealer system.
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
-              <Link href="#pricing" className="rounded-lg bg-emerald-600 px-5 py-3 text-white shadow hover:bg-emerald-700">Get Started</Link>
-              <Link href="#demo" className="rounded-lg border px-5 py-3 text-foreground hover:bg-neutral-50 dark:hover:bg-neutral-900">Explore in Demo</Link>
+              <Link
+                href="#pricing"
+                className="rounded-lg bg-emerald-600 px-5 py-3 text-white shadow hover:bg-emerald-700"
+                onClick={onPriceClick("hero")}
+              >
+                Get Started
+              </Link>
+              <Link
+                href="#demo"
+                className="rounded-lg border px-5 py-3 text-foreground hover:bg-neutral-50 dark:hover:bg-neutral-900"
+              >
+                Explore in Demo
+              </Link>
             </div>
           </div>
           <div className="relative h-[320px] w-full rounded-2xl bg-neutral-100 dark:bg-neutral-800">
-            <Image src="/photos/landing/hero-placeholder.jpg" alt="heroBooks" fill className="rounded-2xl object-cover" sizes="(min-width: 1024px) 600px, 100vw" />
+            <Image
+              src="/photos/landing/hero-placeholder.jpg"
+              alt="heroBooks"
+              fill
+              className="rounded-2xl object-cover"
+              sizes="(min-width: 1024px) 600px, 100vw"
+            />
           </div>
         </div>
       </section>
@@ -50,15 +71,25 @@ export default function HomePage() {
           <div>
             <h2 className="text-2xl font-bold">Why Choose Local?</h2>
             <p className="mt-4 text-muted-foreground">
-              Think local, act local — utilize accounting software that understands
-              and meets the demands of Guyanese businesses.
+              Think local, act local — utilize accounting software that understands and meets the demands of Guyanese businesses.
             </p>
             <div className="mt-6">
-              <Link href="#pricing" className="rounded-lg bg-emerald-600 px-5 py-3 text-white shadow hover:bg-emerald-700">Get Started</Link>
+              <Link
+                href="#pricing"
+                className="rounded-lg bg-emerald-600 px-5 py-3 text-white shadow hover:bg-emerald-700"
+                onClick={onPriceClick("why-local")}
+              >
+                Get Started
+              </Link>
             </div>
           </div>
           <div className="relative h-[300px] w-full rounded-2xl bg-neutral-100 dark:bg-neutral-800">
-            <Image src="/photos/landing/why-placeholder.jpg" alt="Why Local" fill className="rounded-2xl object-cover" />
+            <Image
+              src="/photos/landing/why-placeholder.jpg"
+              alt="Why Local"
+              fill
+              className="rounded-2xl object-cover"
+            />
           </div>
         </div>
       </section>
@@ -73,7 +104,9 @@ export default function HomePage() {
                 <div className="relative mb-4 h-14 w-14 overflow-hidden rounded-full bg-neutral-200">
                   <Image src={`/photos/testimonials/t${i}.jpg`} alt="" fill className="object-cover" />
                 </div>
-                <blockquote className="text-sm text-muted-foreground">“heroBooks keeps our VAT clean and reporting painless.”</blockquote>
+                <blockquote className="text-sm text-muted-foreground">
+                  “heroBooks keeps our VAT clean and reporting painless.”
+                </blockquote>
                 <figcaption className="mt-3 text-sm font-medium">Shop Owner #{i}</figcaption>
               </figure>
             ))}
@@ -84,25 +117,53 @@ export default function HomePage() {
       {/* PRICING */}
       <section id="pricing" className="border-t">
         <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-bold">Simple pricing</h2>
+          <div className="mx-auto max-w-2xl text-center">
+            <h2 className="text-2xl font-bold">Simple pricing</h2>
+            <p className="mt-2 text-sm text-muted-foreground">Start small, scale with your business.</p>
+          </div>
           <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-3">
-            {["Starter", "Business", "Enterprise"].map((name, idx) => (
-              <div key={name} className="rounded-2xl border p-6">
-                <h3 className="text-lg font-semibold">{name}</h3>
-                <p className="mt-1 text-3xl font-extrabold">{idx === 0 ? "$19" : "$49"}<span className="text-base font-medium text-muted-foreground">/mo</span></p>
-                <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
-                  <li>✔ VAT‑ready invoicing</li>
-                  <li>✔ Double‑entry ledger</li>
-                  <li>✔ Reports & exports</li>
-                  <li>{idx > 0 ? "✔ API access" : "— API access"}</li>
-                </ul>
-                <div className="mt-6">
-                  <Link href="#" className="w-full rounded-lg bg-emerald-600 px-4 py-2 text-center text-white hover:bg-emerald-700">
-                    Choose {name}
-                  </Link>
+            {["Starter", "Business", "Enterprise"].map((name, idx) => {
+              const featured = idx === 1;
+              const price = idx === 0 ? "$19" : idx === 1 ? "$49" : "Custom";
+              const onClick = onPriceClick(name.toLowerCase());
+              return (
+                <div
+                  key={name}
+                  className={`relative rounded-2xl border p-6 transition hover:shadow-lg ${
+                    featured ? "border-emerald-500 shadow-emerald-100 dark:shadow-emerald-900/20" : ""
+                  }`}
+                >
+                  {featured && (
+                    <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-emerald-600 px-3 py-1 text-xs font-semibold text-white shadow">
+                      Most Popular
+                    </span>
+                  )}
+                  <h3 className="text-lg font-semibold">{name}</h3>
+                  <p className="mt-1 text-3xl font-extrabold">
+                    {price}
+                    <span className="text-base font-medium text-muted-foreground">{price !== "Custom" ? "/mo" : ""}</span>
+                  </p>
+                  <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+                    <li>✔ VAT‑ready invoicing</li>
+                    <li>✔ Double‑entry ledger</li>
+                    <li>✔ Reports & exports</li>
+                    <li>{idx > 0 ? "✔ API access" : "— API access"}</li>
+                  </ul>
+                  <div className="mt-6">
+                    <button
+                      onClick={onClick}
+                      className={`w-full rounded-lg px-4 py-2 text-center text-white ${
+                        featured
+                          ? "bg-emerald-600 hover:bg-emerald-700"
+                          : "bg-neutral-900 hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200"
+                      }`}
+                    >
+                      {price === "Custom" ? "Contact sales" : `Choose ${name}`}
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </section>
@@ -113,7 +174,10 @@ export default function HomePage() {
           <h2 className="text-2xl font-bold">Frequently asked questions</h2>
           <div className="mt-6 space-y-4">
             {[
-              { q: "How does heroBooks handle VAT?", a: "Invoices can be tagged VAT‑14, zero‑rated, or exempt; exports are ready for filing." },
+              {
+                q: "How does heroBooks handle VAT?",
+                a: "Invoices can be tagged VAT‑14, zero‑rated, or exempt; exports are ready for filing.",
+              },
               { q: "Is there a demo?", a: "Yes — click ‘Explore in Demo’ to try core flows." },
               { q: "Do you have an API?", a: "Yes — clean REST endpoints for integrations." },
             ].map((item) => (
@@ -125,21 +189,6 @@ export default function HomePage() {
           </div>
         </div>
       </section>
-
-      {/* FOOTER */}
-      <footer className="border-t">
-        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 py-12 sm:px-6 lg:px-8 md:flex-row md:items-center md:justify-between">
-          <p className="text-sm text-muted-foreground">© {new Date().getFullYear()} heroBooks</p>
-          <nav className="flex flex-wrap items-center gap-4 text-sm">
-            <a href="#features" className="hover:underline">Features</a>
-            <a href="#pricing" className="hover:underline">Pricing</a>
-            <Link href="/about" className="hover:underline">About</Link>
-            <Link href="/partners" className="hover:underline">Partners</Link>
-            <Link href="/contact" className="hover:underline">Talk to us</Link>
-            <Link href="/legal" className="hover:underline">Terms & Privacy</Link>
-          </nav>
-        </div>
-      </footer>
     </div>
   );
 }

--- a/src/app/(marketing)/partners/page.tsx
+++ b/src/app/(marketing)/partners/page.tsx
@@ -1,5 +1,4 @@
 export const metadata = { title: "Partners — heroBooks" };
-
 export default function PartnersPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+const anchors = [
+  { href: "/#features", label: "Features" },
+  { href: "/#why-local", label: "Why Choose Local" },
+  { href: "/#testimonials", label: "Testimonials" },
+  { href: "/#pricing", label: "Pricing" },
+  { href: "/#faq", label: "FAQ" },
+];
+
+export default function SearchPage() {
+  const params = useSearchParams();
+  const q = (params.get("q") || "").trim();
+  const results = !q ? [] : anchors.filter((a) => a.label.toLowerCase().includes(q.toLowerCase()));
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <h1 className="text-2xl font-bold">Search</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {q ? `Results for "${q}"` : "Type a query in the header to search sections."}
+      </p>
+      <div className="mt-6 grid gap-3">
+        {q && results.length === 0 && (
+          <p className="text-sm text-muted-foreground">No direct matches. Try different keywords.</p>
+        )}
+        {results.map((r) => (
+          <Link
+            key={r.href}
+            href={r.href}
+            className="rounded-xl border p-4 hover:bg-neutral-50 dark:hover:bg-neutral-900"
+          >
+            {r.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,0 +1,85 @@
+"use client";
+import Link from "next/link";
+import { X } from "lucide-react";
+import { recordFeatureImpression } from "@/lib/telemetry";
+
+export default function MobileMenu({
+  open,
+  onClose,
+  anchorLinks,
+}: {
+  open: boolean;
+  onClose: () => void;
+  anchorLinks: { href: string; label: string }[];
+}) {
+  const handleClick = (label: string, href: string) => () => {
+    recordFeatureImpression({ feature: "nav_click", reason: label, path: href });
+    onClose();
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 z-[60] transition ${open ? "visible" : "invisible"}`}
+      aria-hidden={!open}
+    >
+      <div
+        className={`absolute inset-0 bg-black/40 transition-opacity ${open ? "opacity-100" : "opacity-0"}`}
+        onClick={onClose}
+      />
+      <aside
+        className={`absolute right-0 top-0 h-full w-80 max-w-[85%] transform bg-white p-5 shadow-xl transition-transform dark:bg-neutral-900 ${open ? "translate-x-0" : "translate-x-full"}`}
+      >
+        <div className="mb-6 flex items-center justify-between">
+          <span className="text-base font-semibold">Menu</span>
+          <button
+            onClick={onClose}
+            className="rounded-md p-2 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+            aria-label="Close menu"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <nav className="grid gap-3">
+          {anchorLinks.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              onClick={handleClick(l.label, l.href)}
+              className="rounded-lg px-3 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
+            >
+              {l.label}
+            </a>
+          ))}
+          <Link
+            href="/about"
+            onClick={handleClick("About", "/about")}
+            className="rounded-lg px-3 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
+          >
+            About
+          </Link>
+          <Link
+            href="/partners"
+            onClick={handleClick("Partners", "/partners")}
+            className="rounded-lg px-3 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
+          >
+            Partners
+          </Link>
+          <Link
+            href="/contact"
+            onClick={handleClick("Contact", "/contact")}
+            className="rounded-lg px-3 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
+          >
+            Talk to us
+          </Link>
+          <Link
+            href="/legal"
+            onClick={handleClick("Legal", "/legal")}
+            className="rounded-lg px-3 py-2 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
+          >
+            Terms & Privacy
+          </Link>
+        </nav>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/SearchExpand.tsx
+++ b/src/components/SearchExpand.tsx
@@ -1,14 +1,30 @@
 "use client";
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Search } from "lucide-react";
+import { recordFeatureImpression } from "@/lib/telemetry";
 
 export default function SearchExpand() {
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
   const ref = useRef<HTMLInputElement>(null);
+  const router = useRouter();
 
   useEffect(() => {
     if (open) ref.current?.focus();
+  }, [open]);
+
+  // '/' opens search, Esc closes
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "/" && !open) {
+        e.preventDefault();
+        setOpen(true);
+      }
+      if (e.key === "Escape" && open) setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, [open]);
 
   return (
@@ -26,7 +42,9 @@ export default function SearchExpand() {
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            /* TODO: integrate search */
+            recordFeatureImpression({ feature: "search", reason: "header_search", path: location.pathname });
+            router.push(`/search?q=${encodeURIComponent(q)}`);
+            setOpen(false);
           }}
           className="flex items-center gap-2 rounded-xl border bg-white pl-2 pr-2 dark:bg-neutral-900 dark:border-neutral-700"
         >

--- a/src/components/StickyNav.tsx
+++ b/src/components/StickyNav.tsx
@@ -1,9 +1,13 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
-import { Bell, User, ChevronDown } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { Bell, User, ChevronDown, Menu } from "lucide-react";
 import ThemeToggle from "@/components/ThemeToggle";
 import SearchExpand from "@/components/SearchExpand";
+import MobileMenu from "@/components/MobileMenu";
+import { useEffect, useState } from "react";
+import { recordFeatureImpression } from "@/lib/telemetry";
 
 const anchorLinks = [
   { href: "#features", label: "Features" },
@@ -14,10 +18,43 @@ const anchorLinks = [
 ];
 
 export default function StickyNav() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<string>("");
+
+  // Scrollspy for landing sections
+  useEffect(() => {
+    if (pathname !== "/") return;
+    const ids = anchorLinks.map((a) => a.href.slice(1));
+    const els = ids
+      .map((id) => (typeof document !== "undefined" ? document.getElementById(id) : null))
+      .filter(Boolean) as HTMLElement[];
+    if (!els.length) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+        if (visible[0]) setActive(visible[0].target.id);
+      },
+      { rootMargin: "-40% 0px -55% 0px", threshold: [0, 0.1, 0.25, 0.6] }
+    );
+    els.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [pathname]);
+
+  const onNavClick = (label: string, href: string) => () =>
+    recordFeatureImpression({ feature: "nav_click", reason: label, path: href });
+
   return (
     <header className="fixed inset-x-0 top-0 z-50 border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-neutral-900/70">
       <nav className="mx-auto flex h-16 max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
-        <Link href="/" className="flex items-center gap-2 shrink-0" aria-label="heroBooks Home">
+        <Link
+          href="/"
+          className="flex items-center gap-2 shrink-0"
+          aria-label="heroBooks Home"
+          onClick={onNavClick("Home", "/")}
+        >
           <Image
             src="/logos/heroBook%20Full%20Color.svg"
             alt="heroBooks"
@@ -26,22 +63,36 @@ export default function StickyNav() {
             priority
           />
         </Link>
-        <div className="ml-6 hidden flex-1 items-center justify-center md:flex">
+
+        <div className="ml-2 md:ml-6 hidden flex-1 items-center justify-center md:flex">
           <ul className="flex items-center gap-6 text-sm font-medium">
             {anchorLinks.map((l) => (
               <li key={l.href}>
-                <a href={l.href} className="text-muted-foreground hover:text-foreground transition-colors">
+                <a
+                  href={l.href}
+                  onClick={onNavClick(l.label, l.href)}
+                  className={`transition-colors ${
+                    active && l.href.includes(active)
+                      ? "text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
                   {l.label}
                 </a>
               </li>
             ))}
             <li>
-              <Link href="/about" className="text-muted-foreground hover:text-foreground transition-colors">
+              <Link
+                href="/about"
+                onClick={onNavClick("About", "/about")}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
                 About
               </Link>
             </li>
           </ul>
         </div>
+
         <div className="ml-auto flex items-center gap-2">
           <SearchExpand />
           <Link
@@ -59,8 +110,16 @@ export default function StickyNav() {
             <ChevronDown className="h-4 w-4" />
           </button>
           <ThemeToggle />
+          <button
+            className="p-2 md:hidden rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800"
+            aria-label="Open menu"
+            onClick={() => setOpen(true)}
+          >
+            <Menu className="h-5 w-5" />
+          </button>
         </div>
       </nav>
+      <MobileMenu open={open} onClose={() => setOpen(false)} anchorLinks={anchorLinks} />
     </header>
   );
 }

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,20 @@
+export type FeatureImpressionPayload = {
+  feature: string;
+  reason?: string;
+  path?: string;
+  orgId?: string;
+  userId?: string;
+};
+
+export async function recordFeatureImpression(payload: FeatureImpressionPayload) {
+  try {
+    await fetch("/api/telemetry/feature-impression", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch (err) {
+    console.warn("telemetry failed", err);
+  }
+}


### PR DESCRIPTION
## Summary
- add telemetry helper and track nav clicks
- implement mobile drawer menu with active link scrollspy
- add search modal with '/' shortcut and results page
- restyle marketing pricing cards

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcdb1e49308329a13fe5df76e3f12c