### PR TITLE
feat: add marketing About and Contact pages

### DIFF
--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -1,9 +1,112 @@
-export const metadata = { title: "About heroBooks" };
+import Link from "next/link";
+import Image from "next/image";
+import SectionCard from "@/components/UX/SectionCard";
+import Page from "@/components/UX/Page";
+import { asCssVars } from "@/lib/brand-tokens";
+import aboutCopy from "@/lib/copy/about-herobooks";
+
+export const metadata = {
+  title: "About Us — heroBooks",
+  description: "Simple, local-first accounting for Guyana. Learn about our mission, values, and team.",
+};
+
 export default function AboutPage() {
+  const brandVars = asCssVars();
+  const { hero, mission, whoWeAre, values, leadershipHighlights, standards, reachUs } = aboutCopy;
+
   return (
-    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold">About heroBooks</h1>
-      <p className="mt-4 text-muted-foreground">We build modern, local-first accounting tools tailored for Guyanese businesses.</p>
+    <div style={brandVars as any}>
+      <Page title={hero.title} subtitle={hero.subtitle}>
+        <SectionCard id="about-mission" className="mb-8">
+          <span className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold" style={{ background: "var(--brand-tag-bg)", color: "var(--brand-tag-text)" }}>{mission.tag}</span>
+          <h2 className="mt-2 text-2xl font-bold">{mission.headline}</h2>
+          <p className="mt-1 text-[15px] text-slate-600">{mission.body}</p>
+          <ul className="mt-3 space-y-1 text-[15px] text-slate-700">
+            {mission.bullets.map((b) => (<li key={b}>{b}</li>))}
+          </ul>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {mission.ctas.map((c) => (
+              <Link key={c.href} href={c.href} className={c.type === "primary" ? "rounded-xl bg-[var(--brand)] px-4 py-2 font-semibold text-white" : "rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]"}>
+                {c.label}
+              </Link>
+            ))}
+          </div>
+        </SectionCard>
+
+        <div className="mb-8 grid gap-8 lg:grid-cols-2">
+          <SectionCard id="about-who-we-are">
+            <h2 className="text-2xl font-bold">{whoWeAre.title}</h2>
+            {whoWeAre.paragraphs.map((p, i) => (<p key={i} className="mt-2 text-[15px] text-slate-700">{p}</p>))}
+          </SectionCard>
+          <SectionCard id="about-values">
+            <h2 className="text-2xl font-bold">{values.title}</h2>
+            <p className="mt-2 text-[15px] text-slate-700">{values.subtitle}</p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-3">
+              {values.items.map((v) => (
+                <div key={v.t} className="rounded-2xl bg-white p-6 shadow">
+                  <strong className="block">{v.t}</strong>
+                  <p className="mt-1 text-[15px] text-slate-700">{v.d}</p>
+                </div>
+              ))}
+            </div>
+          </SectionCard>
+        </div>
+
+        <SectionCard id="about-leadership" className="mb-8">
+          <span className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold" style={{ background: "var(--brand-tag-bg)", color: "var(--brand-tag-text)" }}>{leadershipHighlights.tag}</span>
+          <h2 className="mt-2 text-2xl font-bold">{leadershipHighlights.title}</h2>
+          <p className="mt-1 text-[15px] text-slate-700">{leadershipHighlights.subtitle}</p>
+          <div className="mt-4 grid gap-6 sm:grid-cols-3">
+            {leadershipHighlights.people.map((p) => (
+              <article key={p.name} className="text-center">
+                <Image src={p.photo} alt={p.name} width={96} height={96} className="mx-auto rounded-full object-cover" />
+                <h3 className="mt-3 text-base font-semibold">{p.name}</h3>
+                <p className="m-0 text-sm text-slate-600">{p.title}</p>
+                <p className="mt-2 text-[15px] text-slate-700">{p.bio}</p>
+              </article>
+            ))}
+          </div>
+          <div className="mt-4 text-center">
+            <Link href="/contact?subject=press" className="inline-block rounded-xl bg-black px-4 py-2 font-semibold text-white">→ {leadershipHighlights.cta}</Link>
+          </div>
+        </SectionCard>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <SectionCard id="about-standards">
+            <h2 className="text-2xl font-bold">{standards.title}</h2>
+            <p className="mt-2 text-[15px] text-slate-700">{standards.intro}</p>
+            <ul className="mt-3 list-disc space-y-1 pl-5 text-[15px] text-slate-700">
+              {standards.bullets.map((b: any) => (
+                <li key={b.label}><strong>{b.label}:</strong> {b.text}</li>
+              ))}
+            </ul>
+            <h3 className="mt-4 text-lg font-semibold">{standards.factCheck.title}</h3>
+            <ol className="list-decimal space-y-2 pl-5 text-[15px] text-slate-700">
+              {standards.factCheck.steps.map((s: string, i: number) => (<li key={i}>{s}</li>))}
+            </ol>
+            <h3 className="mt-4 text-lg font-semibold">{standards.corrections.title}</h3>
+            <p className="text-[15px] text-slate-700">{standards.corrections.text}</p>
+            <div className="mt-3">
+              <Link href="/contact?subject=support" className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-2 text-sm font-semibold text-[var(--brand)]">{standards.corrections.linkText}</Link>
+            </div>
+          </SectionCard>
+          <SectionCard id="about-reach-us">
+            <h2 className="text-2xl font-bold">{reachUs.title}</h2>
+            <p className="mt-2 text-[15px] text-slate-700">{reachUs.desc}</p>
+            <ul className="mt-4 space-y-4">
+              {reachUs.contacts.map((c) => (
+                <li key={c.token} className="list-none">
+                  <Link href={`/contact?subject=${c.token}`} className="rounded-xl bg-black px-4 py-2 text-sm font-semibold text-white">{c.label}</Link>
+                  <p className="mt-1 text-sm text-slate-600">{c.desc}</p>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-4 text-xs text-slate-500">{reachUs.note}</p>
+          </SectionCard>
+        </div>
+      </Page>
+      <footer className="px-4 pb-8 text-center text-slate-500">© {new Date().getFullYear()} heroBooks — All rights reserved.</footer>
     </div>
   );
 }
+

--- a/src/app/(marketing)/contact/ContactClient.tsx
+++ b/src/app/(marketing)/contact/ContactClient.tsx
@@ -1,0 +1,93 @@
+"use client";
+import { useState } from "react";
+import SectionCard from "@/components/UX/SectionCard";
+import Page from "@/components/UX/Page";
+import Toast from "@/components/Toast";
+import contactCopy from "@/lib/copy/contact-herobooks";
+
+type ToastState = { type: "success" | "error"; message: string } | null;
+interface Fields { name: string; email: string; [key: string]: string | undefined }
+
+export default function ContactClient({ initialSubject }: { initialSubject: string }) {
+  const [subject, setSubject] = useState<string>(initialSubject);
+  const [fields, setFields] = useState<Fields>({ name: "", email: "" });
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [toast, setToast] = useState<ToastState>(null);
+
+  const { shared } = contactCopy as any;
+  const current = (contactCopy as any)[subject] || (contactCopy as any).general;
+
+  function updateField(name: string, value: string | undefined) {
+    setFields((f) => ({ ...f, [name]: value }));
+  }
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const payload = { subject, ...fields };
+      const r = await fetch("/api/inbox/create", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+      const json = await r.json();
+      if (!json.ok) throw new Error(json.error || "Failed");
+      setToast({ type: "success", message: current.success.detail || shared.toasts.success });
+      setFields({ name: "", email: "" });
+    } catch {
+      setToast({ type: "error", message: shared.toasts.error });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const SUBJECTS = [
+    { value: "sales", label: "Talk to Sales" },
+    { value: "support", label: "Get Support" },
+    { value: "partnerships", label: "Partnerships" },
+    { value: "press", label: "Press & Speaking" },
+    { value: "careers", label: "Careers" },
+    { value: "billing", label: "Billing" },
+    { value: "general", label: "General" },
+  ];
+
+  return (
+    <div>
+      <Page title={current.hero.title} subtitle={current.hero.subtitle}>
+        <SectionCard id="contact-form">
+          {current.guidance.length > 0 && (
+            <ul className="mb-3 list-disc space-y-1 pl-5 text-sm text-slate-700">{current.guidance.map((g: string, i: number) => (<li key={i}>{g}</li>))}</ul>
+          )}
+          <form onSubmit={onSubmit} className="grid gap-3">
+            <label className="block">
+              <span className="text-sm font-medium">{shared.labels.subject}</span>
+              <select className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" value={subject} onChange={(e) => setSubject(e.target.value)}>
+                {SUBJECTS.map((s) => (<option key={s.value} value={s.value}>{s.label}</option>))}
+              </select>
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium">{shared.labels.name}</span>
+              <input required value={fields.name} onChange={(e) => updateField("name", e.target.value)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium">{shared.labels.email}</span>
+              <input required type="email" value={fields.email} onChange={(e) => updateField("email", e.target.value)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+            </label>
+            {current.fieldsets.map((f: any) => (
+              <label key={f.name} className="block">
+                <span className="text-sm font-medium">{f.label}</span>
+                {f.type === "textarea" ? (
+                  <textarea rows={4} required={f.required} onChange={(e) => updateField(f.name, e.target.value)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+                ) : (
+                  <input type="text" required={f.required} onChange={(e) => updateField(f.name, e.target.value)} className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2" />
+                )}
+              </label>
+            ))}
+            <button type="submit" disabled={submitting} className="mt-2 rounded-xl bg-black px-4 py-2 font-semibold text-white disabled:opacity-60">{submitting ? shared.actions.sending : shared.actions.send}</button>
+          </form>
+          <p className="mt-2 text-xs text-slate-500">{current.meta.privacyShort} <a href="/legal" className="underline">{shared.tips.privacyLink}</a></p>
+        </SectionCard>
+      </Page>
+      {toast && <Toast {...toast} onDone={() => setToast(null)} />}
+    </div>
+  );
+}
+

--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -1,15 +1,9 @@
-export const metadata = { title: "Talk to us — heroBooks" };
-export default function ContactPage() {
-  return (
-    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold">Talk to us</h1>
-      <p className="mt-4 text-muted-foreground">Email: support@herobooks.app</p>
-      <form className="mt-8 grid gap-4">
-        <input className="w-full rounded-lg border p-3" placeholder="Your name" />
-        <input className="w-full rounded-lg border p-3" placeholder="Email" />
-        <textarea className="min-h-[120px] w-full rounded-lg border p-3" placeholder="Message" />
-        <button className="w-fit rounded-lg bg-emerald-600 px-5 py-3 text-white hover:bg-emerald-700">Send</button>
-      </form>
-    </div>
-  );
+import ContactClient from "./ContactClient";
+
+export const metadata = { title: "Contact — heroBooks", description: "Reach sales, support, partnerships, press, billing, or our general inbox." };
+
+export default function ContactPage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
+  const subjectParam = typeof searchParams.subject === "string" ? searchParams.subject.toLowerCase() : "general";
+  return <ContactClient initialSubject={subjectParam} />;
 }
+

--- a/src/app/api/inbox/create/route.ts
+++ b/src/app/api/inbox/create/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Minimal JSON inbox endpoint — NO uploads. Replace internals later to route to DB/email/queue.
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    const name = String(data.name || "").trim();
+    const email = String(data.email || "").trim();
+    const message = String(data.message || data.subjectLine || data.bio || data.goals || "").trim();
+
+    if (!name) return NextResponse.json({ ok: false, error: "Name is required." }, { status: 400 });
+    if (!email) return NextResponse.json({ ok: false, error: "Email is required." }, { status: 400 });
+    if (!message) return NextResponse.json({ ok: false, error: "Message is required." }, { status: 400 });
+
+    // TODO: wire to your actual persistence/notifications
+    // For now just echo back
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: "Bad request" }, { status: 400 });
+  }
+}
+

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { useEffect } from "react";
+
+export default function Toast({ type, message, onDone, timeout = 3200 }: { type: "success" | "error"; message: string; onDone: () => void; timeout?: number }) {
+  useEffect(() => {
+    const t = setTimeout(onDone, timeout);
+    return () => clearTimeout(t);
+  }, [onDone, timeout]);
+  return (
+    <div className="fixed inset-x-0 bottom-4 z-[100] flex justify-center px-4">
+      <div className={`w-full max-w-md rounded-xl border px-4 py-3 text-sm shadow-md ${type === "success" ? "border-emerald-300 bg-emerald-50 text-emerald-900" : "border-red-300 bg-red-50 text-red-900"}`}>
+        {message}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/UX/Page.tsx
+++ b/src/components/UX/Page.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { ReactNode } from "react";
+import { colors } from "@/lib/brand-tokens";
+
+export default function Page({ title, subtitle, children }: { title: string; subtitle?: string; children: ReactNode }) {
+  return (
+    <div>
+      <header
+        className="relative grid min-h-[40vh] place-items-center overflow-hidden px-4 pt-16 text-center text-white"
+        style={{
+          backgroundImage: `linear-gradient(to bottom, ${colors.brandBlue}, ${colors.brandBlueDark}, ${colors.brandBlueDarker})`,
+        }}
+      >
+        <h1 className="text-4xl font-extrabold">{title}</h1>
+        {subtitle && <p className="mt-2 font-serif text-base opacity-95 md:text-lg">{subtitle}</p>}
+      </header>
+      <main className="mx-auto -mt-12 mb-16 max-w-5xl px-4">{children}</main>
+    </div>
+  );
+}
+

--- a/src/components/UX/SectionCard.tsx
+++ b/src/components/UX/SectionCard.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { ReactNode } from "react";
+
+export default function SectionCard({ id, className = "", children }: { id?: string; className?: string; children: ReactNode }) {
+  return (
+    <section id={id} className={`rounded-2xl border bg-white p-6 shadow-sm dark:bg-neutral-900 dark:border-neutral-800 ${className}`}>
+      {children}
+    </section>
+  );
+}
+

--- a/src/lib/brand-tokens.ts
+++ b/src/lib/brand-tokens.ts
@@ -1,0 +1,36 @@
+// heroBooks brand tokens — used by marketing pages (About/Contact) and general theming.
+// These are neutral, easy-to-theme tokens matching the emerald/teal palette from the heroBooks logo.
+export const colors = {
+  // Core brand emerald
+  primary: "#10B981",
+  primaryLight: "#CFFAE6",
+  primaryLighter: "#EDFCF6",
+  primarySoftFrom: "#E6FAF2",
+  primarySoftTo: "#F6FFFB",
+  primaryTagBg: "#E6FBF3",
+  primaryTagText: "#0C8A66",
+  // Gradient header tones (cool neutrals to keep content legible)
+  brandBlue: "#0f766e",
+  brandBlueDark: "#115e59",
+  brandBlueDarker: "#134e4a",
+  gold: "#F2A300", // optional accent
+};
+
+export const fonts = {
+  sans: "'Inter', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji'",
+  serif: "'Merriweather', Georgia, Cambria, 'Times New Roman', Times, serif",
+};
+
+export type BrandVars = Record<string, string>;
+export function asCssVars(): BrandVars {
+  return {
+    "--brand": colors.primary,
+    "--brand-light": colors.primaryLight,
+    "--brand-lighter": colors.primaryLighter,
+    "--brand-soft-from": colors.primarySoftFrom,
+    "--brand-soft-to": colors.primarySoftTo,
+    "--brand-tag-bg": colors.primaryTagBg,
+    "--brand-tag-text": colors.primaryTagText,
+  };
+}
+

--- a/src/lib/copy/about-herobooks.ts
+++ b/src/lib/copy/about-herobooks.ts
@@ -1,0 +1,103 @@
+// Marketing copy for heroBooks About page (can be iterated later)
+const aboutCopy = {
+  hero: {
+    title: "About heroBooks",
+    subtitle: "Simple, local-first accounting — built in Guyana, for Guyana.",
+  },
+  mission: {
+    tag: "Our Mission",
+    headline: "Make bookkeeping effortless for local businesses",
+    body: "We’re building modern accounting that understands VAT, PAYE, NIS, and the realities of running a small business in Guyana.",
+    bullets: [
+      "VAT-ready invoicing and clean, local reports",
+      "Double-entry ledger without the drama",
+      "APIs and integrations that don’t fight you",
+    ],
+    ctas: [
+      { label: "Get Started", href: "/#pricing", type: "primary" },
+      { label: "Talk to Sales", href: "/contact?subject=sales", type: "secondary" },
+    ],
+  },
+  whoWeAre: {
+    title: "Who We Are",
+    paragraphs: [
+      "heroBooks is a small, hands-on team of accountants, engineers, and operators from the region.",
+      "We’re obsessed with clarity, compliance, and speed — so you can spend less time on books and more time on the business.",
+    ],
+  },
+  values: {
+    title: "Our Values",
+    subtitle: "Clarity. Local expertise. Reliability.",
+    items: [
+      { t: "Clarity", d: "Interfaces that make sense — and reports you can actually use." },
+      { t: "Local Expertise", d: "Built for Guyana’s VAT, PAYE, NIS, and statutory filings." },
+      { t: "Reliability", d: "Your books shouldn’t break. Neither should our promises." },
+    ],
+  },
+  leadershipHighlights: {
+    tag: "Leadership",
+    title: "The team guiding our product and customers",
+    subtitle: "Experienced operators who care about local businesses.",
+    people: [
+      {
+        name: "A. Founder",
+        title: "CEO",
+        photo: "/brand/leadership/founder.jpg", // upload manually
+        bio: "Sets product direction and keeps us focused on real customer outcomes.",
+      },
+      {
+        name: "B. Engineer",
+        title: "CTO",
+        photo: "/brand/leadership/cto.jpg", // upload manually
+        bio: "Builds our platform for speed, reliability, and security.",
+      },
+      {
+        name: "C. Finance",
+        title: "Head of Finance & Ops",
+        photo: "/brand/leadership/finance.jpg", // upload manually
+        bio: "Brings deep accounting discipline to every feature and report.",
+      },
+    ],
+    cta: "Meet the team",
+  },
+  standards: {
+    title: "How we ship",
+    intro: "We iterate quickly but hold the line on accuracy and security.",
+    bullets: [
+      { label: "Data Security", text: "Least-privilege access, encrypted in transit and at rest." },
+      { label: "Accuracy", text: "Double-entry core with rigorous tests." },
+      { label: "Support", text: "Humans in the loop — real help when you need it." },
+    ],
+    factCheck: {
+      title: "Change Management",
+      steps: [
+        "Specs & acceptance criteria scoped with customers",
+        "Peer review & automated tests",
+        "Staged rollout and monitoring",
+        "Docs & in‑product guidance",
+      ],
+    },
+    corrections: {
+      title: "If we miss, we fix",
+      text: "Bugs happen — we’ll acknowledge, fix, and document material issues.",
+      linkText: "Report an issue",
+    },
+  },
+  reachUs: {
+    title: "Reach the right team",
+    desc: "Sales questions, support needs, or partnership ideas? We’ve got you.",
+    contacts: [
+      { label: "Talk to Sales", token: "sales", desc: "Licensing, pricing, or demos." },
+      { label: "Get Support", token: "support", desc: "Product usage or account help." },
+      { label: "Partnerships", token: "partnerships", desc: "Banks, POS vendors, integrators." },
+      { label: "Press", token: "press", desc: "Media & speaking." },
+      { label: "Careers", token: "careers", desc: "Join the team." },
+      { label: "General", token: "general", desc: "Anything else." },
+    ],
+    note: "We respect your privacy and local laws.",
+  },
+};
+
+export type AboutCopy = typeof aboutCopy;
+export default aboutCopy;
+

--- a/src/lib/copy/contact-herobooks.ts
+++ b/src/lib/copy/contact-herobooks.ts
@@ -1,0 +1,90 @@
+export type ContactFieldset = { name: string; label: string; type: "text" | "textarea"; required?: boolean };
+export interface ContactSubject {
+  hero: { title: string; subtitle: string };
+  guidance: string[];
+  success: { detail: string };
+  meta: { privacyShort: string };
+  fieldsets: ContactFieldset[];
+}
+
+export const contactCopy = {
+  shared: {
+    labels: { subject: "Subject", name: "Your name", email: "Email" },
+    actions: { send: "Send", sending: "Sending…" },
+    toasts: { success: "Thank you — submitted.", error: "Something went wrong." },
+    tips: { privacyLink: "Privacy Policy" },
+  },
+  sales: {
+    hero: { title: "Talk to Sales", subtitle: "Licensing, pricing, demos." },
+    guidance: ["Tell us about your business and your timeline."],
+    success: { detail: "Thanks — we’ll reach out shortly." },
+    meta: { privacyShort: "We only use your info to respond to this inquiry." },
+    fieldsets: [
+      { name: "company", label: "Company", type: "text" },
+      { name: "message", label: "What do you need?", type: "textarea", required: true },
+    ],
+  },
+  support: {
+    hero: { title: "Get Support", subtitle: "We’re here to help." },
+    guidance: ["Include steps to reproduce if it’s a bug."],
+    success: { detail: "Support request received." },
+    meta: { privacyShort: "We only use your info to reply." },
+    fieldsets: [
+      { name: "subjectLine", label: "Subject", type: "text", required: true },
+      { name: "message", label: "Describe the issue", type: "textarea", required: true },
+    ],
+  },
+  partnerships: {
+    hero: { title: "Partnerships", subtitle: "Banks, POS, and integrators." },
+    guidance: [],
+    success: { detail: "Thanks — we’ll follow up soon." },
+    meta: { privacyShort: "We only use your info for partnership discussions." },
+    fieldsets: [
+      { name: "org", label: "Organization", type: "text" },
+      { name: "message", label: "How can we partner?", type: "textarea", required: true },
+    ],
+  },
+  press: {
+    hero: { title: "Press & Speaking", subtitle: "Media inquiries." },
+    guidance: [],
+    success: { detail: "Thanks — our team will respond." },
+    meta: { privacyShort: "We only use your info to respond to press inquiries." },
+    fieldsets: [
+      { name: "outlet", label: "Outlet", type: "text" },
+      { name: "message", label: "How can we help?", type: "textarea", required: true },
+    ],
+  },
+  careers: {
+    hero: { title: "Careers", subtitle: "Join the team." },
+    guidance: [],
+    success: { detail: "Thanks — we’ll be in touch." },
+    meta: { privacyShort: "We use your info only for recruiting." },
+    fieldsets: [
+      { name: "role", label: "Role of interest", type: "text" },
+      { name: "message", label: "Tell us about yourself", type: "textarea", required: true },
+    ],
+  },
+  billing: {
+    hero: { title: "Billing", subtitle: "Invoices and payments." },
+    guidance: [],
+    success: { detail: "Thanks — we’ll reply shortly." },
+    meta: { privacyShort: "We only use your info to reply." },
+    fieldsets: [
+      { name: "accountId", label: "Account ID (if any)", type: "text" },
+      { name: "message", label: "What do you need?", type: "textarea", required: true },
+    ],
+  },
+  general: {
+    hero: { title: "Contact heroBooks", subtitle: "We read every message." },
+    guidance: [],
+    success: { detail: "Thanks — message received." },
+    meta: { privacyShort: "We only use your info to reply." },
+    fieldsets: [
+      { name: "message", label: "Message", type: "textarea", required: true },
+    ],
+  },
+} as const;
+
+export type ContactCopy = typeof contactCopy;
+export default contactCopy;
+


### PR DESCRIPTION
## Summary
- add brand tokens and UX primitives (SectionCard, Page, Toast)
- build WaterNews-style About and Contact pages powered by new copy files
- expose minimal JSON inbox endpoint at `/api/inbox/create`

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Type error in StickyNav.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bcee5cd7b48329a45cd810a2a99c60