### PR TITLE
Add metadata descriptions for marketing pages

### DIFF
--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -7,7 +7,7 @@ import aboutCopy from "@/lib/copy/about-herobooks";
 
 export const metadata = {
   title: "About Us — heroBooks",
-  description: "Simple, local-first accounting for Guyana. Learn about our mission, values, and team.",
+  description: "Learn about heroBooks' mission, values, and the team behind local-first accounting.",
 };
 
 export default function AboutPage() {

--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -1,6 +1,10 @@
 import ContactClient from "./ContactClient";
 
-export const metadata = { title: "Contact — heroBooks", description: "Reach sales, support, partnerships, press, billing, or our general inbox." };
+export const metadata = {
+  title: "Contact — heroBooks",
+  description:
+    "Contact heroBooks for sales, support, partnerships, press, billing, or general inquiries.",
+};
 
 export default function ContactPage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
   const subjectParam = typeof searchParams.subject === "string" ? searchParams.subject.toLowerCase() : "general";


### PR DESCRIPTION
## Summary
- add concise descriptions to About and Contact marketing pages for richer metadata

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Type error in src/components/StickyNav.tsx)*
- `pnpm dev` and `curl -s http://localhost:3000/about | grep -o '<title>.*</title>'`
- `curl -s http://localhost:3000/about | grep -o '<meta name="description" content="[^"]*"'`
- `curl -s http://localhost:3000/contact | grep -o '<title>.*</title>'`
- `curl -s http://localhost:3000/contact | grep -o '<meta name="description" content="[^"]*"'`


------
https://chatgpt.com/codex/tasks/task_e_68bcf20196c88329a0fd2d93bbe9c6a5