### PR TITLE
feat: add inbox API and contact form handler

### DIFF
--- a/src/app/(marketing)/contact/ContactClient.tsx
+++ b/src/app/(marketing)/contact/ContactClient.tsx
@@ -9,8 +9,9 @@ type ToastState = { type: "success" | "error"; message: string } | null;
 interface Fields { name: string; email: string; [key: string]: string | undefined }
 
 export default function ContactClient({ initialSubject }: { initialSubject: string }) {
+  const initialFields: Fields = { name: "", email: "" };
   const [subject, setSubject] = useState<string>(initialSubject);
-  const [fields, setFields] = useState<Fields>({ name: "", email: "" });
+  const [fields, setFields] = useState<Fields>(initialFields);
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [toast, setToast] = useState<ToastState>(null);
 
@@ -31,9 +32,9 @@ export default function ContactClient({ initialSubject }: { initialSubject: stri
       const json = await r.json();
       if (!json.ok) throw new Error(json.error || "Failed");
       setToast({ type: "success", message: current.success.detail || shared.toasts.success });
-      setFields({ name: "", email: "" });
-    } catch {
-      setToast({ type: "error", message: shared.toasts.error });
+      setFields(initialFields);
+    } catch (err: any) {
+      setToast({ type: "error", message: err?.message || shared.toasts.error });
     } finally {
       setSubmitting(false);
     }
@@ -105,6 +106,7 @@ export default function ContactClient({ initialSubject }: { initialSubject: stri
                     name={f.name}
                     rows={4}
                     required={f.required}
+                    value={fields[f.name] || ""}
                     onChange={(e) => updateField(f.name, e.target.value)}
                     className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
                   />
@@ -114,6 +116,7 @@ export default function ContactClient({ initialSubject }: { initialSubject: stri
                     name={f.name}
                     type="text"
                     required={f.required}
+                    value={fields[f.name] || ""}
                     onChange={(e) => updateField(f.name, e.target.value)}
                     className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
                   />

--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -8,6 +8,7 @@ export const metadata = {
 
 export default function ContactPage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
   const subjectParam = typeof searchParams.subject === "string" ? searchParams.subject.toLowerCase() : "general";
-  return <ContactClient initialSubject={subjectParam} />;
+  // key ensures component resets when subject changes
+  return <ContactClient key={subjectParam} initialSubject={subjectParam} />;
 }
 

--- a/src/app/api/inbox/create/route.ts
+++ b/src/app/api/inbox/create/route.ts
@@ -1,21 +1,31 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+const InboxSchema = z
+  .object({
+    name: z.string().min(1, "Name is required."),
+    email: z.string().email("Valid email is required."),
+    message: z.string().min(1, "Message is required."),
+  })
+  .passthrough();
 
 // Minimal JSON inbox endpoint — NO uploads. Replace internals later to route to DB/email/queue.
-export async function POST(req: NextRequest) {
+export async function POST(req: Request) {
   try {
-    const data = await req.json();
-    const name = String(data.name || "").trim();
-    const email = String(data.email || "").trim();
-    const message = String(data.message || data.subjectLine || data.bio || data.goals || "").trim();
-
-    if (!name) return NextResponse.json({ ok: false, error: "Name is required." }, { status: 400 });
-    if (!email) return NextResponse.json({ ok: false, error: "Email is required." }, { status: 400 });
-    if (!message) return NextResponse.json({ ok: false, error: "Message is required." }, { status: 400 });
+    const json = await req.json();
+    const parsed = InboxSchema.safeParse(json);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      return NextResponse.json(
+        { ok: false, error: issue?.message || "Invalid input" },
+        { status: 400 }
+      );
+    }
 
     // TODO: wire to your actual persistence/notifications
-    // For now just echo back
+    // For now just echo back success
     return NextResponse.json({ ok: true });
-  } catch (e) {
+  } catch {
     return NextResponse.json({ ok: false, error: "Bad request" }, { status: 400 });
   }
 }


### PR DESCRIPTION
## Summary
- validate inbox submissions with a zod schema and return clear errors
- enhance marketing contact form with controlled fields and toast feedback
- ensure contact page resets form when subject changes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcf3768ffc8329bca0b9d3a7d12ee8