### PR TITLE
Wrap nav with SessionProvider and trim inbox inputs

### DIFF
--- a/src/app/api/inbox/create/route.ts
+++ b/src/app/api/inbox/create/route.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 
 const InboxSchema = z
   .object({
-    name: z.string().min(1, "Name is required."),
-    email: z.string().email("Valid email is required."),
-    message: z.string().min(1, "Message is required."),
+    name: z.string().trim().min(1, "Name is required."),
+    email: z.string().trim().email("Valid email is required."),
+    message: z.string().trim().min(1, "Message is required."),
   })
   .passthrough();
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { ReactNode } from "react";
 import { Inter } from "next/font/google";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
+import { SessionProvider } from "next-auth/react";
 import StickyNav from "@/components/StickyNav";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -18,10 +19,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} bg-background text-foreground`}>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <StickyNav />
-          <main className="pt-16">{children}</main>
-        </ThemeProvider>
+        <SessionProvider>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <StickyNav />
+            <main className="pt-16">{children}</main>
+          </ThemeProvider>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/components/StickyNav.tsx
+++ b/src/components/StickyNav.tsx
@@ -50,7 +50,7 @@ export default function StickyNav() {
   const onNavClick = (label: string, href: string) => () =>
     recordFeatureImpression({ feature: "nav_click", reason: label, path: href });
 
-  if (status === "loading" || status === "pending") {
+  if (status === "loading") {
     return (
       <header className="fixed inset-x-0 top-0 z-50 border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-neutral-900/70">
         <nav className="mx-auto flex h-16 max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- provide SessionProvider around StickyNav and remove unsupported session status
- trim inbox API fields before Zod validation

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bcfbffd4f08329811e50359509309f