### PR TITLE
feat: add customer stories and testimonial expansions

### DIFF
--- a/src/app/(marketing)/stories/StoriesListing.tsx
+++ b/src/app/(marketing)/stories/StoriesListing.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { stories } from "@/lib/stories";
+import { recordFeatureImpression } from "@/lib/telemetry";
+
+const filters = [
+  { tag: "all", label: "All" },
+  { tag: "retail", label: "Retail" },
+  { tag: "beauty", label: "Beauty" },
+  { tag: "logistics", label: "Logistics" },
+  { tag: "dealership", label: "Dealership" },
+  { tag: "construction", label: "Construction" },
+  { tag: "real-estate", label: "Real Estate" },
+  { tag: "schools", label: "Schools" },
+];
+
+const PAGE_SIZE = 3;
+
+export default function StoriesListing() {
+  const [filter, setFilter] = useState("all");
+  const [page, setPage] = useState(1);
+
+  const filtered = stories
+    .filter((s) => s.consent_obtained)
+    .filter((s) => filter === "all" || s.tags.includes(filter));
+
+  const visible = filtered.slice(0, page * PAGE_SIZE);
+
+  useEffect(() => {
+    recordFeatureImpression({
+      feature: "stories_view",
+      meta: { filter, page },
+    });
+  }, [filter, page]);
+
+  const onFilter = (tag: string) => {
+    setFilter(tag);
+    setPage(1);
+    recordFeatureImpression({ feature: "stories_filter", meta: { tag } });
+  };
+
+  const loadMore = () => {
+    const next = page + 1;
+    setPage(next);
+    recordFeatureImpression({ feature: "stories_load_more", meta: { page: next } });
+  };
+
+  return (
+    <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+      <h1 className="text-2xl font-bold">Customer stories</h1>
+      <p className="mt-2 text-muted-foreground">
+        Real operations using heroBooks for Guyana—VAT, PAYE, and NIS in the flow.
+      </p>
+
+      <div className="mt-6">
+        <span className="text-sm font-medium">Filter by sector</span>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {filters.map((f) => (
+            <button
+              key={f.tag}
+              onClick={() => onFilter(f.tag)}
+              className={`rounded-full border px-3 py-1 text-sm ${
+                filter === f.tag ? "bg-foreground text-background" : "bg-background"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <label className="text-sm font-medium" htmlFor="stories-sort">
+          Sort by
+        </label>
+        <select id="stories-sort" className="ml-2 rounded-md border px-2 py-1 text-sm">
+          <option>Newest</option>
+        </select>
+      </div>
+
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+        {visible.length ? (
+          visible.map((story) => (
+            <div key={story.id} className="flex flex-col overflow-hidden rounded-2xl border">
+              <div className="relative h-40 w-full overflow-hidden">
+                <Image src={story.image_src} alt={story.persona.name} fill className="object-cover" />
+              </div>
+              <div className="flex flex-1 flex-col p-4">
+                <h3 className="font-semibold">{story.title}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {story.persona.name} — {story.persona.role}, {story.persona.location}
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">{story.teaser}</p>
+                <Link
+                  href={`/stories/${story.slug}`}
+                  className="mt-auto text-sm font-medium underline"
+                >
+                  See how heroBooks works for them
+                </Link>
+              </div>
+            </div>
+          ))
+        ) : (
+          <p>No stories yet for this sector.</p>
+        )}
+      </div>
+
+      {visible.length < filtered.length && (
+        <div className="mt-8 text-center">
+          <button
+            onClick={loadMore}
+            className="rounded-lg border px-4 py-2 text-sm font-medium"
+          >
+            Load more stories
+          </button>
+        </div>
+      )}
+
+      <p className="mt-8 text-center text-xs text-muted-foreground">
+        Testimonials reflect individual experiences. Your results may vary.
+      </p>
+    </section>
+  );
+}

--- a/src/app/(marketing)/stories/[slug]/StoryDetail.tsx
+++ b/src/app/(marketing)/stories/[slug]/StoryDetail.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect } from "react";
+import { Story, stories } from "@/lib/stories";
+import { recordFeatureImpression } from "@/lib/telemetry";
+
+export default function StoryDetail({ story }: { story: Story }) {
+  useEffect(() => {
+    recordFeatureImpression({ feature: "story_view", meta: { story_id: story.id } });
+  }, [story.id]);
+
+  useEffect(() => {
+    const thresholds = [25, 50, 75, 100];
+    function onScroll() {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const scrolled = (scrollTop / docHeight) * 100;
+      while (thresholds.length && scrolled >= thresholds[0]) {
+        const depth = thresholds.shift()!;
+        recordFeatureImpression({
+          feature: "story_scroll_depth",
+          meta: { story_id: story.id, depth },
+        });
+      }
+    }
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [story.id]);
+
+  const related = stories
+    .filter((s) => s.id !== story.id && s.consent_obtained)
+    .slice(0, 3);
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16">
+      <div className="relative h-60 w-full overflow-hidden rounded-xl">
+        <Image src={story.image_src} alt={story.persona.name} fill className="object-cover" />
+      </div>
+      <h1 className="mt-4 text-2xl font-bold">{story.title}</h1>
+      <p className="mt-2 text-muted-foreground">
+        {story.persona.name} — {story.persona.role}, {story.persona.location}
+      </p>
+      <div className="mt-6 space-y-4">
+        {story.summary_lines.map((line) => (
+          <p key={line}>{line}</p>
+        ))}
+      </div>
+      {story.features_used.length > 0 && (
+        <div className="mt-6">
+          <h2 className="font-semibold">What they used</h2>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {story.features_used.map((f) => (
+              <span key={f} className="rounded-full bg-muted px-3 py-1 text-xs">
+                {f}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="mt-8 flex flex-col gap-4 sm:flex-row">
+        <Link
+          href={story.cta_href}
+          className="rounded-lg bg-emerald-600 px-5 py-3 text-center text-white"
+          onClick={() =>
+            recordFeatureImpression({
+              feature: "story_cta_click",
+              meta: { story_id: story.id, label: story.cta_label, href: story.cta_href },
+            })
+          }
+        >
+          {story.cta_label}
+        </Link>
+        <Link
+          href={story.try_setup_href}
+          className="rounded-lg border px-5 py-3 text-center"
+          onClick={() =>
+            recordFeatureImpression({
+              feature: "story_cta_click",
+              meta: { story_id: story.id, label: "Try this setup", href: story.try_setup_href },
+            })
+          }
+        >
+          Try this setup
+        </Link>
+      </div>
+      {related.length > 0 && (
+        <div className="mt-12">
+          <h2 className="font-semibold">More stories like this</h2>
+          <div className="mt-4 grid gap-6 sm:grid-cols-2">
+            {related.map((s) => (
+              <div key={s.id} className="flex flex-col overflow-hidden rounded-2xl border">
+                <div className="relative h-32 w-full overflow-hidden">
+                  <Image src={s.image_src} alt={s.persona.name} fill className="object-cover" />
+                </div>
+                <div className="flex flex-col p-4">
+                  <h3 className="font-semibold">{s.title}</h3>
+                  <p className="mt-1 text-sm text-muted-foreground">{s.teaser}</p>
+                  <Link
+                    href={`/stories/${s.slug}`}
+                    className="mt-auto text-sm font-medium underline"
+                  >
+                    See how heroBooks works for them
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <p className="mt-8 text-xs text-muted-foreground">
+        Information provided by heroBooks is general in nature and not a substitute for professional tax or legal advice. Testimonials reflect individual experiences. Your results may vary.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(marketing)/stories/[slug]/page.tsx
+++ b/src/app/(marketing)/stories/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+import StoryDetail from "./StoryDetail";
+import { stories, getStoryBySlug } from "@/lib/stories";
+
+export function generateStaticParams() {
+  return stories.map((s) => ({ slug: s.slug }));
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const story = getStoryBySlug(params.slug);
+  if (!story) return { robots: { index: false, follow: false } };
+  return {
+    title: story.title,
+    robots: { index: false, follow: false },
+  };
+}
+
+export default function StoryPage({ params }: { params: { slug: string } }) {
+  const story = getStoryBySlug(params.slug);
+  if (!story) notFound();
+  return <StoryDetail story={story} />;
+}

--- a/src/app/(marketing)/stories/page.tsx
+++ b/src/app/(marketing)/stories/page.tsx
@@ -1,0 +1,10 @@
+import StoriesListing from "./StoriesListing";
+
+export const metadata = {
+  title: "Customer stories",
+  robots: { index: false, follow: false },
+};
+
+export default function StoriesPage() {
+  return <StoriesListing />;
+}

--- a/src/components/marketing/TestimonialsSection.tsx
+++ b/src/components/marketing/TestimonialsSection.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { testimonialCopy } from "@/lib/copy/imageCopy";
 import { chooseOnce } from "@/lib/randomize";
 import { recordFeatureImpression } from "@/lib/telemetry";
+import { getStoryById } from "@/lib/stories";
 
 const headings = [
   "Trusted by local professionals",
@@ -15,6 +16,8 @@ const headings = [
 export default function TestimonialsSection() {
   const heading = chooseOnce("hb_testimonial_heading", headings);
   const entries = Object.entries(testimonialCopy);
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+
   useEffect(() => {
     recordFeatureImpression({
       feature: "testimonial_impression",
@@ -31,14 +34,50 @@ export default function TestimonialsSection() {
         <h2 className="text-2xl font-bold text-center md:text-left">{heading}</h2>
         <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
           {entries.map(([id, t]) => {
-            const quote = t.quotes[Math.floor(Math.random() * t.quotes.length)];
+            const story = getStoryById(t.storyId);
             const imgSrc = `/photos/testimonials/${id}.webp`;
+            const isOpen = open[id];
             return (
               <div key={id} className="rounded-2xl border p-6 flex flex-col gap-4 bg-muted/30">
                 <div className="relative h-24 w-24 overflow-hidden rounded-xl border">
                   <Image src={imgSrc} alt={t.name} fill className="object-cover" />
                 </div>
-                <p className="text-sm leading-snug">“{quote}”</p>
+                <p className="text-sm leading-snug">“{t.quote}”</p>
+                <p className="text-xs">{t.teaser}</p>
+                <button
+                  className="mt-2 text-sm font-medium underline"
+                  onClick={() => {
+                    const next = { ...open, [id]: !isOpen };
+                    setOpen(next);
+                    if (!isOpen) {
+                      recordFeatureImpression({
+                        feature: "case_study_open",
+                        meta: { story_id: t.storyId, placement: "testimonials_inline" },
+                      });
+                    }
+                  }}
+                >
+                  See how heroBooks works for them
+                </button>
+                {isOpen && story && (
+                  <div className="mt-4 flex flex-col gap-2 text-sm">
+                    {story.summary_lines.map((line) => (
+                      <p key={line}>{line}</p>
+                    ))}
+                    <a
+                      href={story.try_setup_href}
+                      className="mt-2 inline-block text-sm font-medium underline"
+                      onClick={() =>
+                        recordFeatureImpression({
+                          feature: "case_study_try_setup_click",
+                          meta: { story_id: t.storyId, href: story.try_setup_href },
+                        })
+                      }
+                    >
+                      Try this setup
+                    </a>
+                  </div>
+                )}
                 <div className="mt-auto text-xs text-muted-foreground">
                   <div className="font-medium text-foreground">{t.name}</div>
                   <div>{t.role}</div>

--- a/src/lib/copy/imageCopy.ts
+++ b/src/lib/copy/imageCopy.ts
@@ -86,28 +86,28 @@ export const testimonialCopy = {
   "shop-owner": {
     name: "Sasha",
     role: "Retail, Georgetown",
-    quotes: [
-      "We used to close late at month-end. With heroBooks, sales and VAT are always current—and I finally know my numbers without guessing.",
-      "Bank imports reconcile in minutes. I spend less time stressing and more time serving customers.",
-    ],
+    quote:
+      "We used to close late at month-end. With heroBooks, sales and VAT are always current—and I finally know my numbers without guessing. Month-end used to scare me; now I just reconcile and file.",
+    teaser: "Daily sales + VAT kept current—month-end without the scramble.",
+    storyId: "story_retail_sasha_georgetown",
     since: "Since 2024",
   },
   "salon-owner": {
     name: "Maya",
     role: "Beauty, East Bank",
-    quotes: [
-      "Bookings, receipts, PAYE—everything in one place. I can send an invoice from my phone before the client leaves.",
-      "Payroll used to scare me. Now it’s just part of closing the week.",
-    ],
+    quote:
+      "Bookings, receipts, PAYE—everything in one place. I can send an invoice from my phone before the client leaves. Payroll used to scare me; now it’s just part of closing the week.",
+    teaser: "Invoices from the chair, PAYE handled at week-end.",
+    storyId: "story_beauty_maya_eastbank",
     since: "Since 2024",
   },
   "transport-owner": {
     name: "Devon",
     role: "Logistics, Bartica Road",
-    quotes: [
-      "From quotes to delivery receipts, we keep jobs moving and the books clean. Even fuel and tolls reconcile faster.",
-      "Less spreadsheet chaos, more on-time runs—and reporting that actually mirrors the work.",
-    ],
+    quote:
+      "From quotes to delivery receipts, we keep jobs moving and the books clean. Even fuel and tolls reconcile faster. Less spreadsheet chaos, more on-time runs—and reporting that actually mirrors the work.",
+    teaser: "Quotes → delivery receipts → VAT—jobs flow into the books.",
+    storyId: "story_logistics_devon_bartica",
     since: "Since 2023",
   },
 } as const;

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -1,0 +1,146 @@
+export interface Story {
+  id: string;
+  slug: string;
+  title: string;
+  persona: { name: string; role: string; location: string };
+  image_src: string;
+  teaser: string;
+  summary_lines: string[];
+  features_used: string[];
+  cta_label: string;
+  cta_href: string;
+  try_setup_href: string;
+  tags: string[];
+  published_at: string | null;
+  consent_obtained: boolean;
+  anonymized: boolean;
+}
+
+export const stories: Story[] = [
+  {
+    id: "story_retail_sasha_georgetown",
+    slug: "sasha-retail-georgetown",
+    title: "Sales tidy, VAT on time",
+    persona: { name: "Sasha", role: "Shop Owner", location: "Georgetown" },
+    image_src: "/photos/landing/accounting.webp",
+    teaser: "How Sasha uses daily sales tracking to stay VAT-ready.",
+    summary_lines: [
+      "Logged daily sales and expenses so VAT is always up to date.",
+      "Used bank import rules to reconcile cash and card quickly.",
+      "Filed VAT without the usual month-end scramble.",
+    ],
+    features_used: ["Sales tracking", "Bank import & rules", "VAT returns"],
+    cta_label: "See retail tools",
+    cta_href: "/features/retail",
+    try_setup_href: "/features?stack=retail_simple",
+    tags: ["retail", "vat", "bank-import", "guyana"],
+    published_at: "2024-05-01",
+    consent_obtained: true,
+    anonymized: false,
+  },
+  {
+    id: "story_beauty_maya_eastbank",
+    slug: "maya-beauty-eastbank",
+    title: "Invoices from the chair",
+    persona: { name: "Maya", role: "Stylist", location: "East Bank" },
+    image_src: "/photos/landing/salon.webp",
+    teaser: "How Maya uses mobile invoicing and PAYE payroll to keep chairs turning.",
+    summary_lines: [
+      "Sent invoices from the chair and tracked payments by client.",
+      "Ran PAYE payroll each week without spreadsheets.",
+      "Grouped product sales and tips for clean month-end reports.",
+    ],
+    features_used: ["Mobile invoicing", "PAYE payroll", "Sales tracking"],
+    cta_label: "See beauty workflow",
+    cta_href: "/features/beauty",
+    try_setup_href: "/features?stack=beauty_chair",
+    tags: ["beauty", "paye", "invoicing", "guyana"],
+    published_at: "2024-05-10",
+    consent_obtained: true,
+    anonymized: false,
+  },
+  {
+    id: "story_logistics_devon_bartica",
+    slug: "devon-logistics-bartica",
+    title: "Jobs flowing into the books",
+    persona: { name: "Devon", role: "Transport Owner", location: "Bartica Road" },
+    image_src: "/photos/landing/logistics.webp",
+    teaser: "How Devon uses quotes and delivery receipts to keep VAT in the flow.",
+    summary_lines: [
+      "Converted quotes to delivery receipts with VAT applied.",
+      "Tracked fuel and tolls per job via bank import rules.",
+      "Saw job profitability before month-end.",
+    ],
+    features_used: ["Quotes→Invoices", "Delivery receipts", "Bank import & rules"],
+    cta_label: "See logistics tools",
+    cta_href: "/features/logistics",
+    try_setup_href: "/features?stack=logistics_flow",
+    tags: ["logistics", "vat", "bank-import", "guyana"],
+    published_at: "2024-05-20",
+    consent_obtained: true,
+    anonymized: false,
+  },
+  {
+    id: "story_dealership_ryan_georgetown",
+    slug: "ryan-dealership-georgetown",
+    title: "Every unit’s true cost—at a glance",
+    persona: { name: "Ryan", role: "Dealer", location: "Georgetown" },
+    image_src: "/photos/landing/dealership.webp",
+    teaser: "How Ryan uses per-unit COGS to price with confidence.",
+    summary_lines: [
+      "Tracked purchase, duty, and reconditioning on each unit for real margins.",
+      "Switched quotes → invoices with VAT in one click—no double entry.",
+      "Consolidated multi-location sales and stock without spreadsheet chaos.",
+    ],
+    features_used: [
+      "Inventory/COGS (per-unit)",
+      "Quotes→Invoices",
+      "VAT invoicing",
+      "Multi-location",
+      "P&L by location",
+    ],
+    cta_label: "See dealership tools",
+    cta_href: "/features/dealership",
+    try_setup_href: "/features?stack=dealership_pro",
+    tags: ["dealership", "inventory", "vat", "cogs", "guyana"],
+    published_at: null,
+    consent_obtained: false,
+    anonymized: false,
+  },
+  {
+    id: "story_construction_keisha_linden",
+    slug: "keisha-construction-linden",
+    title: "Jobs on schedule, books in sync",
+    persona: { name: "Keisha", role: "Contractor", location: "Linden" },
+    image_src: "/photos/landing/construction.webp",
+    teaser: "How Keisha uses job tracking and progress billing to stay on schedule.",
+    summary_lines: [
+      "Used projects/jobs to group quotes, invoices, and expenses per site.",
+      "Adopted progress billing and kept VAT straight across stages.",
+      "Reconciled fuel, materials, sub-contractors via bank import and rules.",
+    ],
+    features_used: [
+      "Projects/Jobs",
+      "Quotes→Invoices",
+      "Progress billing",
+      "VAT",
+      "Bank import & rules",
+      "Job profitability",
+    ],
+    cta_label: "See construction workflow",
+    cta_href: "/features/construction",
+    try_setup_href: "/features?stack=construction_jobs",
+    tags: ["construction", "projects", "vat", "bank-import", "guyana"],
+    published_at: null,
+    consent_obtained: false,
+    anonymized: false,
+  },
+];
+
+export function getStoryBySlug(slug: string) {
+  return stories.find((s) => s.slug === slug);
+}
+
+export function getStoryById(id: string) {
+  return stories.find((s) => s.id === id);
+}


### PR DESCRIPTION
## Summary
- add story data and draft entries for dealership and construction
- expand testimonial cards with inline case summaries and analytics
- build noindexed stories listing and detail pages with filters and telemetry

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd2a2d29048329a499dbb2bef44113