### PR TITLE
Add seed stories and coming soon overlay

### DIFF
--- a/public/photos/README.txt
+++ b/public/photos/README.txt
@@ -22,6 +22,8 @@ Testimonial Images:
 - shop-owner.webp
 - salon-owner.webp
 - transport-owner.webp
+- dealer-ryan.webp
+- contractor-keisha.webp
 
 Notes:
 - All images are 1024x1024 WebP format

--- a/src/app/(marketing)/stories/StoriesListing.tsx
+++ b/src/app/(marketing)/stories/StoriesListing.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import ComingSoonOverlay from "@/components/marketing/ComingSoonOverlay";
 import { stories } from "@/lib/stories";
 import { recordFeatureImpression } from "@/lib/telemetry";
 
@@ -23,9 +24,9 @@ export default function StoriesListing() {
   const [filter, setFilter] = useState("all");
   const [page, setPage] = useState(1);
 
-  const filtered = stories
-    .filter((s) => s.consent_obtained)
-    .filter((s) => filter === "all" || s.tags.includes(filter));
+  const filtered = stories.filter(
+    (s) => filter === "all" || s.tags.includes(filter)
+  );
 
   const visible = filtered.slice(0, page * PAGE_SIZE);
 
@@ -84,9 +85,17 @@ export default function StoriesListing() {
       <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
         {visible.length ? (
           visible.map((story) => (
-            <div key={story.id} className="flex flex-col overflow-hidden rounded-2xl border">
+            <div
+              key={story.id}
+              className="relative flex flex-col overflow-hidden rounded-2xl border"
+            >
               <div className="relative h-40 w-full overflow-hidden">
-                <Image src={story.image_src} alt={story.persona.name} fill className="object-cover" />
+                <Image
+                  src={story.image_src}
+                  alt={story.image_alt ?? story.persona.name}
+                  fill
+                  className="object-cover"
+                />
               </div>
               <div className="flex flex-1 flex-col p-4">
                 <h3 className="font-semibold">{story.title}</h3>
@@ -94,13 +103,18 @@ export default function StoriesListing() {
                   {story.persona.name} — {story.persona.role}, {story.persona.location}
                 </p>
                 <p className="mt-2 text-sm text-muted-foreground">{story.teaser}</p>
-                <Link
-                  href={`/stories/${story.slug}`}
-                  className="mt-auto text-sm font-medium underline"
-                >
-                  See how heroBooks works for them
-                </Link>
+                {story.consent_obtained && (
+                  <Link
+                    href={`/stories/${story.slug}`}
+                    className="mt-auto text-sm font-medium underline"
+                  >
+                    See how heroBooks works for them
+                  </Link>
+                )}
               </div>
+              {!story.consent_obtained && (
+                <ComingSoonOverlay story={story} trySetup />
+              )}
             </div>
           ))
         ) : (

--- a/src/app/(marketing)/stories/[slug]/StoryDetail.tsx
+++ b/src/app/(marketing)/stories/[slug]/StoryDetail.tsx
@@ -36,7 +36,12 @@ export default function StoryDetail({ story }: { story: Story }) {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16">
       <div className="relative h-60 w-full overflow-hidden rounded-xl">
-        <Image src={story.image_src} alt={story.persona.name} fill className="object-cover" />
+        <Image
+          src={story.image_src}
+          alt={story.image_alt ?? story.persona.name}
+          fill
+          className="object-cover"
+        />
       </div>
       <h1 className="mt-4 text-2xl font-bold">{story.title}</h1>
       <p className="mt-2 text-muted-foreground">
@@ -92,7 +97,12 @@ export default function StoryDetail({ story }: { story: Story }) {
             {related.map((s) => (
               <div key={s.id} className="flex flex-col overflow-hidden rounded-2xl border">
                 <div className="relative h-32 w-full overflow-hidden">
-                  <Image src={s.image_src} alt={s.persona.name} fill className="object-cover" />
+                <Image
+                  src={s.image_src}
+                  alt={s.image_alt ?? s.persona.name}
+                  fill
+                  className="object-cover"
+                />
                 </div>
                 <div className="flex flex-col p-4">
                   <h3 className="font-semibold">{s.title}</h3>

--- a/src/components/marketing/ComingSoonOverlay.tsx
+++ b/src/components/marketing/ComingSoonOverlay.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import { recordFeatureImpression } from "@/lib/telemetry";
+import { Story } from "@/lib/stories";
+
+export default function ComingSoonOverlay({
+  story,
+  trySetup = false,
+}: {
+  story: Story;
+  trySetup?: boolean;
+}) {
+  useEffect(() => {
+    recordFeatureImpression({
+      feature: "story_overlay_view",
+      meta: { story_id: story.id, status: "pending consent" },
+    });
+  }, [story.id]);
+
+  return (
+    <div
+      className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background/90 p-4 text-center"
+      aria-label={`Story coming soon: ${story.title}. Awaiting customer approval`}
+    >
+      <span
+        className="absolute right-2 top-2 rounded bg-amber-200 px-2 py-1 text-xs font-medium text-amber-800"
+        title="Awaiting customer approval"
+      >
+        Pending consent
+      </span>
+      <div className="text-lg font-semibold">Coming soon</div>
+      <div className="text-sm">Awaiting customer approval</div>
+      <button
+        className="mt-2 cursor-not-allowed rounded-lg border px-3 py-1 text-sm opacity-60"
+        disabled
+        title="This story will be available shortly."
+        onMouseEnter={() =>
+          recordFeatureImpression({
+            feature: "story_overlay_cta_hover",
+            meta: { story_id: story.id },
+          })
+        }
+      >
+        See how heroBooks works for them
+      </button>
+      {trySetup && (
+        <a
+          href={story.try_setup_href}
+          className="mt-1 text-sm font-medium underline"
+          onClick={() =>
+            recordFeatureImpression({
+              feature: "story_overlay_try_setup_click",
+              meta: { story_id: story.id, href: story.try_setup_href },
+            })
+          }
+        >
+          Try this setup
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/components/marketing/TestimonialsSection.tsx
+++ b/src/components/marketing/TestimonialsSection.tsx
@@ -6,6 +6,7 @@ import { testimonialCopy } from "@/lib/copy/imageCopy";
 import { chooseOnce } from "@/lib/randomize";
 import { recordFeatureImpression } from "@/lib/telemetry";
 import { getStoryById } from "@/lib/stories";
+import ComingSoonOverlay from "@/components/marketing/ComingSoonOverlay";
 
 const headings = [
   "Trusted by local professionals",
@@ -60,22 +61,27 @@ export default function TestimonialsSection() {
                   See how heroBooks works for them
                 </button>
                 {isOpen && story && (
-                  <div className="mt-4 flex flex-col gap-2 text-sm">
+                  <div className="relative mt-4 flex flex-col gap-2 text-sm">
                     {story.summary_lines.map((line) => (
                       <p key={line}>{line}</p>
                     ))}
-                    <a
-                      href={story.try_setup_href}
-                      className="mt-2 inline-block text-sm font-medium underline"
-                      onClick={() =>
-                        recordFeatureImpression({
-                          feature: "case_study_try_setup_click",
-                          meta: { story_id: t.storyId, href: story.try_setup_href },
-                        })
-                      }
-                    >
-                      Try this setup
-                    </a>
+                    {story.consent_obtained && (
+                      <a
+                        href={story.try_setup_href}
+                        className="mt-2 inline-block text-sm font-medium underline"
+                        onClick={() =>
+                          recordFeatureImpression({
+                            feature: "case_study_try_setup_click",
+                            meta: { story_id: t.storyId, href: story.try_setup_href },
+                          })
+                        }
+                      >
+                        Try this setup
+                      </a>
+                    )}
+                    {!story.consent_obtained && (
+                      <ComingSoonOverlay story={story} trySetup />
+                    )}
                   </div>
                 )}
                 <div className="mt-auto text-xs text-muted-foreground">

--- a/src/lib/copy/imageCopy.ts
+++ b/src/lib/copy/imageCopy.ts
@@ -110,6 +110,24 @@ export const testimonialCopy = {
     storyId: "story_logistics_devon_bartica",
     since: "Since 2023",
   },
+  "dealer-ryan": {
+    name: "Ryan",
+    role: "Dealership, Georgetown",
+    quote:
+      "Purchase, duty, and reconditioning tracked per unit—real margins without guesswork.",
+    teaser: "Every unit’s true cost—at a glance",
+    storyId: "story_dealership_ryan_georgetown",
+    since: "Since 2024",
+  },
+  "contractor-keisha": {
+    name: "Keisha",
+    role: "Construction, Linden",
+    quote:
+      "Progress billing and job costs aligned—profitability in view before month-end.",
+    teaser: "Jobs on schedule, books in sync",
+    storyId: "story_construction_keisha_linden",
+    since: "Since 2024",
+  },
 } as const;
 
 export const bannerCopy = {

--- a/src/lib/stories.ts
+++ b/src/lib/stories.ts
@@ -4,6 +4,7 @@ export interface Story {
   title: string;
   persona: { name: string; role: string; location: string };
   image_src: string;
+  image_alt?: string;
   teaser: string;
   summary_lines: string[];
   features_used: string[];
@@ -81,11 +82,58 @@ export const stories: Story[] = [
     anonymized: false,
   },
   {
+    id: "story_realestate_ayanna_alberttown",
+    slug: "ayanna-real-estate-alberttown",
+    title: "Rent rolls and reports made simple",
+    persona: { name: "Ayanna", role: "Property Manager", location: "Alberttown" },
+    image_src: "/photos/landing/real-estate.webp",
+    image_alt: "Property manager reviewing rent roll reports",
+    teaser: "Automated rent and owner statements—month-end without manual math.",
+    summary_lines: [
+      "Automated recurring invoices for monthly rent and utilities.",
+      "Kept deposits and receipts organized for audits.",
+      "Ran clean owner statements without manual math.",
+      "“Tenants happier; month-end calmer.”",
+    ],
+    features_used: ["Recurring invoices", "Deposits", "Receipts", "Owner statements"],
+    cta_label: "See real-estate tools",
+    cta_href: "/features/real-estate",
+    try_setup_href: "/features?stack=realestate_recurring",
+    tags: ["real-estate", "recurring", "receipts", "reports", "guyana"],
+    published_at: null,
+    consent_obtained: false,
+    anonymized: false,
+  },
+  {
+    id: "story_schoolboard_marcus_newamsterdam",
+    slug: "marcus-school-board-new-amsterdam",
+    title: "Grant tracking with real transparency",
+    persona: { name: "Marcus", role: "School Board Treasurer", location: "New Amsterdam" },
+    image_src: "/photos/landing/school-board.webp",
+    image_alt: "Treasurer reviewing school grant allocations",
+    teaser: "Grant tracking and audit prep without spreadsheet chaos.",
+    summary_lines: [
+      "Managed grants and fees with clear allocations.",
+      "Streamlined audit prep using consistent categories and receipts.",
+      "Published summary reports for board meetings in minutes.",
+      "“Less paperwork, more accountability.”",
+    ],
+    features_used: ["Categories", "Receipts", "Reports", "Audit prep"],
+    cta_label: "See education tools",
+    cta_href: "/features/education",
+    try_setup_href: "/features?stack=school_transparency",
+    tags: ["schools", "education", "grants", "audit", "receipts", "reports", "guyana"],
+    published_at: null,
+    consent_obtained: false,
+    anonymized: false,
+  },
+  {
     id: "story_dealership_ryan_georgetown",
     slug: "ryan-dealership-georgetown",
     title: "Every unit’s true cost—at a glance",
     persona: { name: "Ryan", role: "Dealer", location: "Georgetown" },
     image_src: "/photos/landing/dealership.webp",
+    image_alt: "Dealer reviewing unit costs and margins",
     teaser: "How Ryan uses per-unit COGS to price with confidence.",
     summary_lines: [
       "Tracked purchase, duty, and reconditioning on each unit for real margins.",
@@ -113,6 +161,7 @@ export const stories: Story[] = [
     title: "Jobs on schedule, books in sync",
     persona: { name: "Keisha", role: "Contractor", location: "Linden" },
     image_src: "/photos/landing/construction.webp",
+    image_alt: "Contractor on site checking project costs and billing",
     teaser: "How Keisha uses job tracking and progress billing to stay on schedule.",
     summary_lines: [
       "Used projects/jobs to group quotes, invoices, and expenses per site.",


### PR DESCRIPTION
## Summary
- seed future Real Estate and School Board stories
- add Ryan and Keisha testimonial teasers
- introduce consent-aware Coming Soon overlay for stories and testimonials
- remove committed testimonial images (public/photos/testimonials/contractor-keisha.webp, public/photos/testimonials/dealer-ryan.webp)

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd2c6fa8408329833d5dca19111094