### PR TITLE
Exclude draft stories and fix testimonials randomizer

### DIFF
--- a/src/app/(marketing)/stories/[slug]/page.tsx
+++ b/src/app/(marketing)/stories/[slug]/page.tsx
@@ -3,12 +3,15 @@ import StoryDetail from "./StoryDetail";
 import { stories, getStoryBySlug } from "@/lib/stories";
 
 export function generateStaticParams() {
-  return stories.map((s) => ({ slug: s.slug }));
+  return stories
+    .filter((s) => s.consent_obtained)
+    .map((s) => ({ slug: s.slug }));
 }
 
 export function generateMetadata({ params }: { params: { slug: string } }) {
   const story = getStoryBySlug(params.slug);
-  if (!story) return { robots: { index: false, follow: false } };
+  if (!story || !story.consent_obtained)
+    return { robots: { index: false, follow: false } };
   return {
     title: story.title,
     robots: { index: false, follow: false },
@@ -17,6 +20,6 @@ export function generateMetadata({ params }: { params: { slug: string } }) {
 
 export default function StoryPage({ params }: { params: { slug: string } }) {
   const story = getStoryBySlug(params.slug);
-  if (!story) notFound();
+  if (!story || !story.consent_obtained) notFound();
   return <StoryDetail story={story} />;
 }

--- a/src/components/marketing/TestimonialsSection.tsx
+++ b/src/components/marketing/TestimonialsSection.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import { testimonialCopy } from "@/lib/copy/imageCopy";
-import { chooseOnce } from "@/lib/randomize";
 import { recordFeatureImpression } from "@/lib/telemetry";
 import { getStoryById } from "@/lib/stories";
 import ComingSoonOverlay from "@/components/marketing/ComingSoonOverlay";
@@ -15,9 +14,13 @@ const headings = [
 ];
 
 export default function TestimonialsSection() {
-  const heading = chooseOnce("hb_testimonial_heading", headings);
+  const [heading, setHeading] = useState(headings[0]);
   const entries = Object.entries(testimonialCopy);
   const [open, setOpen] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setHeading(headings[Math.floor(Math.random() * headings.length)]);
+  }, []);
 
   useEffect(() => {
     recordFeatureImpression({


### PR DESCRIPTION
## Summary
- avoid generating or serving story pages for stories without consent
- replace server-only randomizer in TestimonialsSection with client-safe variant

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e4a5c8483298164a5e0c3259fae