### PR TITLE
chore: add knowledge base scaffold

### DIFF
--- a/kb/README.md
+++ b/kb/README.md
@@ -1,0 +1,30 @@
+# heroBooks Knowledge Base
+
+This folder contains the content and indexes for the heroBooks Knowledge Base.
+
+## Structure
+
+- `taxonomy.json` — hierarchical list of categories and topics.
+- `articles/` — Markdown articles with YAML front‑matter.
+- `kb_assist_index.json` — snippets and assistant keys compiled from articles.
+- `search_index.json` — basic search index for titles and tags.
+- `right_rail.yaml` — NIS/GRA quick links, popular snippets, internal promos.
+- `brand_options.md` — candidate banner slogans.
+
+## Maintenance
+
+1. Update articles regularly; set `last_reviewed` to the current ISO date.
+2. Verify all rates and thresholds against official GRA and NIS sources.
+3. Run `pnpm lint` before committing to ensure formatting and types are valid.
+4. Rebuild `kb_assist_index.json` and `search_index.json` after adding or editing articles.
+
+## Review Cycle
+
+Facts tied to filing periods or statutory rates should be reviewed every 6 months.
+Use analytics events to flag articles with old `last_reviewed` dates.
+
+## Sourcing Policy
+
+Prefer primary sources such as the Guyana Revenue Authority, National Insurance Scheme,
+and Caribbean Examinations Council. Secondary sources may supplement but must be
+clearly attributed.

--- a/kb/articles/double-entry-explained.md
+++ b/kb/articles/double-entry-explained.md
@@ -1,0 +1,33 @@
+id: double-entry-explained
+slug: double-entry-explained
+title: Double-entry explained (with GYD examples)
+summary: An introduction to the double-entry system using Guyanese dollar examples.
+level: Beginner
+audience: [Owner, Student]
+format: Concept
+category_id: getting-started
+tags: ["double entry", bookkeeping]
+jurisdiction: [Guyana, CARICOM]
+last_reviewed: 2024-05-01
+sources:
+  - title: "IFRS for SMEs Section 2"
+    url: "https://www.ifrs.org/ifrs-for-smes/"
+    publisher: "IFRS Foundation"
+    date_accessed: 2024-05-01
+kb_snippets:
+  - question: "What is double-entry accounting?"
+    answer: "Every transaction records equal debits and credits."
+    type: "definition"
+assistant_keys: []
+body_markdown: |
+  ### Intro
+  Double-entry bookkeeping records the debit and credit of each transaction.
+
+  ### Local nuances (Guyana)
+  The method is standard under IFRS and applies to GY businesses.
+
+  ### Example
+  Buying supplies for GYD 5,000 on credit: debit Supplies 5,000; credit Accounts Payable 5,000.
+
+  ### References
+  - IFRS Foundation: IFRS for SMEs, Section 2.

--- a/kb/articles/paye-thresholds-guyana.md
+++ b/kb/articles/paye-thresholds-guyana.md
@@ -1,0 +1,38 @@
+id: paye-thresholds-guyana
+slug: paye-thresholds-guyana
+title: PAYE: thresholds, bands, and calculations (Guyana)
+summary: Explains current PAYE tax bands and how to compute deductions.
+level: Intermediate
+audience: [Accountant, Clerk]
+format: Guide
+category_id: payroll-paye-nis
+tags: [PAYE, payroll]
+jurisdiction: [Guyana]
+last_reviewed: 2024-05-01
+sources:
+  - title: "Income Tax Act of Guyana"
+    url: "https://www.gra.gov.gy/income-tax-act"
+    publisher: "GRA"
+    date_accessed: 2024-05-01
+kb_snippets:
+  - question: "What is the personal allowance for PAYE in Guyana?"
+    answer: "As at 2024 the annual allowance is GYD 960,000."
+    type: "faq"
+assistant_keys:
+  - intent: "ASK"
+    key: "paye_thresholds"
+    synonyms: ["PAYE rates", "income tax bands"]
+    link: "/dashboard/settings/payroll"
+body_markdown: |
+  ### Intro
+  PAYE is withheld from employee salaries and remitted monthly.
+
+  ### Current thresholds (2024)
+  - Personal allowance: GYD 960,000 per year.
+  - Tax rate: 28% up to GYD 2,040,000, then 40%.
+
+  ### Calculation example
+  An employee earning GYD 200,000 monthly pays 28% on the taxable portion after allowance.
+
+  ### References
+  - Guyana Income Tax Act.

--- a/kb/articles/vat-invoice-requirements.md
+++ b/kb/articles/vat-invoice-requirements.md
@@ -1,0 +1,37 @@
+id: vat-invoice-requirements
+slug: vat-invoice-requirements
+title: What makes a VAT-compliant invoice in Guyana?
+summary: Key details that every Guyanese VAT invoice must include.
+level: Beginner
+audience: [Owner, Clerk]
+format: Checklist
+category_id: sales-vat
+tags: [VAT, invoicing]
+jurisdiction: [Guyana]
+last_reviewed: 2024-05-01
+sources:
+  - title: "VAT Act of Guyana"
+    url: "https://www.gra.gov.gy/vat-act"
+    publisher: "GRA"
+    date_accessed: 2024-05-01
+kb_snippets:
+  - question: "Which items are mandatory on a VAT invoice in Guyana?"
+    answer: "Name and TIN of supplier, invoice number, date, description, taxable amount, VAT at 14%."
+    type: "howto"
+assistant_keys:
+  - intent: "DO"
+    key: "vat_invoice_create"
+    synonyms: ["VAT invoice", "tax invoice"]
+    link: "/dashboard/invoices/new"
+body_markdown: |
+  ### Intro
+  VAT-registered businesses must issue invoices with specific fields.
+
+  ### Requirements
+  Include supplier name and TIN, customer details, invoice number and date, description, taxable value, VAT rate and amount.
+
+  ### Local nuances (Guyana)
+  The standard rate is 14% as of 2024. Show prices in GYD and state if zero-rated.
+
+  ### References
+  - GRA VAT Act guidance.

--- a/kb/brand_options.md
+++ b/kb/brand_options.md
@@ -1,0 +1,12 @@
+# Knowledge Base Banner Slogans
+
+1. **PoA for Guyana — Learn it. Run it.**
+   - Emphasizes local relevance and action.
+2. **heroBooks Academy — Your Guyanese Accounting Companion**
+   - Frames the KB as a learning partner.
+3. **PoA Hub: From CXC Basics to Business Brilliance**
+   - Connects students to entrepreneurs.
+4. **heroAccounting Library — Trusted Guidance for GY SMEs**
+   - Highlights reliability for small businesses.
+5. **Caribbean Ledger — Simple Answers, Real Compliance**
+   - Positions the KB within the wider region.

--- a/kb/kb_assist_index.json
+++ b/kb/kb_assist_index.json
@@ -1,0 +1,38 @@
+{
+  "snippets": [
+    {
+      "article_id": "double-entry-explained",
+      "question": "What is double-entry accounting?",
+      "answer": "Every transaction records equal debits and credits.",
+      "type": "definition"
+    },
+    {
+      "article_id": "vat-invoice-requirements",
+      "question": "Which items are mandatory on a VAT invoice in Guyana?",
+      "answer": "Name and TIN of supplier, invoice number, date, description, taxable amount, VAT at 14%.",
+      "type": "howto"
+    },
+    {
+      "article_id": "paye-thresholds-guyana",
+      "question": "What is the personal allowance for PAYE in Guyana?",
+      "answer": "As at 2024 the annual allowance is GYD 960,000.",
+      "type": "faq"
+    }
+  ],
+  "assistant_keys": [
+    {
+      "article_id": "vat-invoice-requirements",
+      "intent": "DO",
+      "key": "vat_invoice_create",
+      "synonyms": ["VAT invoice", "tax invoice"],
+      "link": "/dashboard/invoices/new"
+    },
+    {
+      "article_id": "paye-thresholds-guyana",
+      "intent": "ASK",
+      "key": "paye_thresholds",
+      "synonyms": ["PAYE rates", "income tax bands"],
+      "link": "/dashboard/settings/payroll"
+    }
+  ]
+}

--- a/kb/right_rail.yaml
+++ b/kb/right_rail.yaml
@@ -1,0 +1,23 @@
+nis_links:
+  - title: "NIS Contribution Rates"
+    url: "https://www.nis.org.gy/contributions"
+  - title: "NIS Employer Forms"
+    url: "https://www.nis.org.gy/forms"
+
+gra_links:
+  - title: "GRA VAT Portal"
+    url: "https://etax.gra.gov.gy"
+  - title: "GRA Forms"
+    url: "https://www.gra.gov.gy/forms"
+
+popular_snippets:
+  - question: "What is the VAT rate in Guyana?"
+    answer: "The standard VAT rate is 14% as at 2024."
+  - question: "How often do I file PAYE?"
+    answer: "Employers submit monthly PAYE returns to the GRA."
+
+promos:
+  - text: "Invite your accountant"
+    link: "/dashboard/settings/team"
+  - text: "Import bank file"
+    link: "/dashboard/banking/import"

--- a/kb/search_index.json
+++ b/kb/search_index.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "double-entry-explained",
+    "title": "Double-entry explained (with GYD examples)",
+    "summary": "An introduction to the double-entry system using Guyanese dollar examples.",
+    "tags": ["double entry", "bookkeeping"],
+    "category_id": "getting-started",
+    "jurisdiction": ["Guyana", "CARICOM"],
+    "snippets": ["Every transaction records equal debits and credits."]
+  },
+  {
+    "id": "vat-invoice-requirements",
+    "title": "What makes a VAT-compliant invoice in Guyana?",
+    "summary": "Key details that every Guyanese VAT invoice must include.",
+    "tags": ["VAT", "invoicing"],
+    "category_id": "sales-vat",
+    "jurisdiction": ["Guyana"],
+    "snippets": ["Name and TIN of supplier, invoice number, date, description, taxable amount, VAT at 14%."]
+  },
+  {
+    "id": "paye-thresholds-guyana",
+    "title": "PAYE: thresholds, bands, and calculations (Guyana)",
+    "summary": "Explains current PAYE tax bands and how to compute deductions.",
+    "tags": ["PAYE", "payroll"],
+    "category_id": "payroll-paye-nis",
+    "jurisdiction": ["Guyana"],
+    "snippets": ["As at 2024 the annual allowance is GYD 960,000."]
+  }
+]

--- a/kb/taxonomy.json
+++ b/kb/taxonomy.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "getting-started",
+    "title": "Getting Started (PoA Basics)",
+    "slug": "getting-started",
+    "children": [
+      {"id": "double-entry", "title": "Double Entry", "slug": "double-entry"},
+      {"id": "chart-of-accounts", "title": "Chart of Accounts", "slug": "chart-of-accounts"},
+      {"id": "accrual-vs-cash", "title": "Accrual vs Cash", "slug": "accrual-vs-cash"},
+      {"id": "trial-balance", "title": "Trial Balance", "slug": "trial-balance"},
+      {"id": "adjusting-entries", "title": "Adjusting Entries", "slug": "adjusting-entries"}
+    ]
+  },
+  {
+    "id": "sales-vat",
+    "title": "Sales, Invoicing & VAT",
+    "slug": "sales-vat",
+    "children": [
+      {"id": "vat-invoice", "title": "VAT Invoices", "slug": "vat-invoice"},
+      {"id": "zero-rated", "title": "Zero-rated vs Exempt", "slug": "zero-rated"},
+      {"id": "sales-returns", "title": "Sales Returns", "slug": "sales-returns"},
+      {"id": "credit-notes", "title": "Credit & Debit Notes", "slug": "credit-notes"},
+      {"id": "vat-filing", "title": "VAT Filing", "slug": "vat-filing"}
+    ]
+  },
+  {
+    "id": "purchases-expenses",
+    "title": "Purchases, Expenses & Payables",
+    "slug": "purchases-expenses",
+    "children": [
+      {"id": "expense-categorization", "title": "Expense Categorization", "slug": "expense-categorization"},
+      {"id": "supplier-bills", "title": "Supplier Bills vs Expenses", "slug": "supplier-bills"},
+      {"id": "withholding-tax", "title": "Withholding Tax", "slug": "withholding-tax"},
+      {"id": "petty-cash", "title": "Petty Cash Controls", "slug": "petty-cash"}
+    ]
+  },
+  {
+    "id": "banking-reconciliation",
+    "title": "Banking & Reconciliation",
+    "slug": "banking-reconciliation",
+    "children": [
+      {"id": "import-bank-files", "title": "Importing Bank Files", "slug": "import-bank-files"},
+      {"id": "bank-rules", "title": "Bank Rules", "slug": "bank-rules"},
+      {"id": "merchant-fees", "title": "Merchant Fees & Chargebacks", "slug": "merchant-fees"}
+    ]
+  },
+  {
+    "id": "payroll-paye-nis",
+    "title": "Payroll, PAYE & NIS",
+    "slug": "payroll-paye-nis",
+    "children": [
+      {"id": "paye-thresholds", "title": "PAYE Thresholds", "slug": "paye-thresholds"},
+      {"id": "nis-contributions", "title": "NIS Contributions", "slug": "nis-contributions"},
+      {"id": "payroll-journal-entries", "title": "Payroll Journal Entries", "slug": "payroll-journal-entries"},
+      {"id": "year-end-payroll", "title": "Year-end Payroll Reporting", "slug": "year-end-payroll"}
+    ]
+  },
+  {
+    "id": "inventory-cogs",
+    "title": "Inventory & COGS (incl. Dealerships)",
+    "slug": "inventory-cogs",
+    "children": [
+      {"id": "vehicle-cogs", "title": "Vehicle Dealer COGS", "slug": "vehicle-cogs"},
+      {"id": "inventory-valuation", "title": "Inventory Valuation Methods", "slug": "inventory-valuation"},
+      {"id": "stock-counts", "title": "Stock Counts & Shrinkage", "slug": "stock-counts"}
+    ]
+  },
+  {
+    "id": "projects-jobs",
+    "title": "Projects & Jobs (Construction)",
+    "slug": "projects-jobs",
+    "children": [
+      {"id": "job-costing", "title": "Job Costing", "slug": "job-costing"},
+      {"id": "progress-billing", "title": "Progress Billing", "slug": "progress-billing"},
+      {"id": "project-dashboard", "title": "Project Profitability Dashboard", "slug": "project-dashboard"}
+    ]
+  },
+  {
+    "id": "fixed-assets",
+    "title": "Fixed Assets & Depreciation",
+    "slug": "fixed-assets",
+    "children": [
+      {"id": "capitalization-policy", "title": "Capitalization Policy", "slug": "capitalization-policy"},
+      {"id": "depreciation-methods", "title": "Depreciation Methods", "slug": "depreciation-methods"},
+      {"id": "asset-disposal", "title": "Asset Disposal", "slug": "asset-disposal"}
+    ]
+  },
+  {
+    "id": "financial-reporting",
+    "title": "Financial Statements & Reporting",
+    "slug": "financial-reporting",
+    "children": [
+      {"id": "financial-statements", "title": "Financial Statements", "slug": "financial-statements"},
+      {"id": "aging-schedules", "title": "Aging Schedules", "slug": "aging-schedules"},
+      {"id": "audit-trail", "title": "Audit Trail Basics", "slug": "audit-trail"}
+    ]
+  },
+  {
+    "id": "compliance",
+    "title": "Compliance (GRA, VAT, NIS, PAYE)",
+    "slug": "compliance",
+    "children": [
+      {"id": "registering-vat", "title": "Registering for VAT", "slug": "registering-vat"},
+      {"id": "filing-vat-online", "title": "Filing VAT Online", "slug": "filing-vat-online"},
+      {"id": "nis-registration", "title": "NIS Employer Registration", "slug": "nis-registration"},
+      {"id": "compliance-penalties", "title": "Compliance Penalties", "slug": "compliance-penalties"}
+    ]
+  },
+  {
+    "id": "real-estate",
+    "title": "Real Estate & Property Management",
+    "slug": "real-estate",
+    "children": [
+      {"id": "rent-roll", "title": "Rent Roll Setup", "slug": "rent-roll"},
+      {"id": "security-deposits", "title": "Security Deposits", "slug": "security-deposits"},
+      {"id": "owner-statements", "title": "Owner Statements", "slug": "owner-statements"}
+    ]
+  },
+  {
+    "id": "education-cxc",
+    "title": "Education (CXC PoA Study Guides)",
+    "slug": "education-cxc",
+    "children": [
+      {"id": "cxc-syllabus", "title": "CXC PoA Syllabus", "slug": "cxc-syllabus"},
+      {"id": "journal-entries-exam", "title": "Exam Journal Entries", "slug": "journal-entries-exam"},
+      {"id": "trial-balance-exam", "title": "Trial Balance & Corrections", "slug": "trial-balance-exam"}
+    ]
+  },
+  {
+    "id": "internal-controls",
+    "title": "Internal Controls & Best Practices",
+    "slug": "internal-controls",
+    "children": [
+      {"id": "cash-controls", "title": "Cash Controls", "slug": "cash-controls"},
+      {"id": "segregation-duties", "title": "Segregation of Duties", "slug": "segregation-duties"}
+    ]
+  },
+  {
+    "id": "industry-guides",
+    "title": "Industry Guides (Retail, Beauty/Salon, Logistics, Schools, NGOs)",
+    "slug": "industry-guides",
+    "children": [
+      {"id": "retail", "title": "Retail Shops", "slug": "retail"},
+      {"id": "salon", "title": "Beauty & Salon", "slug": "salon"},
+      {"id": "logistics", "title": "Logistics", "slug": "logistics"},
+      {"id": "schools-ngos", "title": "Schools & NGOs", "slug": "schools-ngos"}
+    ]
+  },
+  {
+    "id": "api-integrations",
+    "title": "API & Integrations (Pro)",
+    "slug": "api-integrations",
+    "children": [
+      {"id": "export-reports", "title": "Exporting Reports", "slug": "export-reports"},
+      {"id": "dealer-system-hookups", "title": "Dealer System Hookups", "slug": "dealer-system-hookups"}
+    ]
+  }
+]

--- a/src/app/kb/layout.tsx
+++ b/src/app/kb/layout.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import Image from "next/image";
+import ThemeToggle from "@/components/topbar/ThemeToggle";
+import NotificationsBell from "@/components/topbar/NotificationsBell";
+import UserMenu from "@/components/topbar/UserMenu";
+import React from "react";
+
+export default function KnowledgeBaseLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="h-screen flex flex-col">
+      <header className="flex items-center justify-between border-b p-2">
+        <div className="flex items-center gap-2">
+          <Link href="/" aria-label="Back">
+            ←
+          </Link>
+          <Link href="/">
+            <Image src="/logo.svg" alt="heroBooks" width={100} height={24} />
+          </Link>
+        </div>
+        <input
+          type="search"
+          placeholder="Search KB"
+          className="border rounded px-2 py-1 w-1/3"
+        />
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <NotificationsBell />
+          <UserMenu />
+        </div>
+      </header>
+      <div className="flex flex-1 overflow-hidden">
+        <aside className="w-60 border-r overflow-y-auto p-4">Contents</aside>
+        <main className="flex-1 overflow-y-auto p-4">{children}</main>
+        <aside className="w-60 border-l overflow-y-auto p-4">Right rail</aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/kb/page.tsx
+++ b/src/app/kb/page.tsx
@@ -1,0 +1,8 @@
+export default function KnowledgeBaseHome() {
+  return (
+    <article>
+      <h1 className="text-2xl font-bold mb-4">Knowledge Base</h1>
+      <p>Select an article from the left to begin.</p>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold knowledge base directory with taxonomy and sample articles
- add right-rail links, search and assist indexes, and branding options
- introduce `/kb` route with basic header and three-pane layout

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd44cf3da48329abcb50058cd31740