### PR TITLE
feat: redesign pricing and add floating trial CTA

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,6 +1,7 @@
 import "../globals.css";
 import MarketingHeader from "@/components/marketing/MarketingHeader";
 import MarketingFooter from "@/components/marketing/MarketingFooter";
+import FloatingTrialCTA from "@/components/marketing/FloatingTrialCTA";
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -8,6 +9,7 @@ export default function MarketingLayout({ children }: { children: React.ReactNod
       <MarketingHeader />
       <main className="pt-14">{children}</main>
       <MarketingFooter />
+      <FloatingTrialCTA />
     </>
   );
 }

--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -15,78 +15,97 @@ export default function PricingPage({ searchParams }: { searchParams: Record<str
     typeof nextRaw === "string" && nextRaw.startsWith("/") && !nextRaw.startsWith("//")
       ? nextRaw
       : "/sign-up";
-  const highlightRaw = (Array.isArray(searchParams?.highlight) ? searchParams.highlight[0] : searchParams?.highlight) || "business";
-  const highlight = (["starter", "business", "enterprise"].includes(highlightRaw) ? highlightRaw : "business") as PlanKey;
+  const highlightRaw = (Array.isArray(searchParams?.highlight) ? searchParams.highlight[0] : searchParams?.highlight) || "essentials";
+  const highlight = (["starter", "essentials", "growth", "pro"].includes(highlightRaw) ? highlightRaw : "essentials") as PlanKey;
 
   return (
-    <section className="container mx-auto px-4 py-12">
-      <div className="text-center max-w-2xl mx-auto">
-        <h1 className="text-3xl font-semibold">Simple pricing for every stage</h1>
-        <p className="text-muted-foreground mt-2">Transparent plans in GYD. All include VAT-ready invoicing and core reports.</p>
-      </div>
-
-      {/* Cards */}
-      <div className="mt-8 grid gap-6 md:grid-cols-3">
-        <div className="rounded-2xl border bg-card p-6 flex flex-col">
-          <div className="text-sm font-medium">Starter</div>
-          <div className="text-3xl font-semibold mt-1">GYD $0</div>
-          <div className="text-xs text-muted-foreground">during beta</div>
-          <ul className="mt-4 space-y-2">
-            <Row>Up to 2 users</Row>
-            <Row>Invoices & receipts (PDF/email)</Row>
-            <Row>VAT 14% + zero-rated/exempt items</Row>
-            <Row>Trial Balance & P&amp;L</Row>
-            <Row>Email support</Row>
-          </ul>
-          <Button asChild className="mt-6">
-            <Link href={`${next}?plan=starter`}>Start free</Link>
-          </Button>
+    <section className="w-full bg-orange-50">
+      <div className="container mx-auto px-4 py-12">
+        <div className="text-center max-w-2xl mx-auto">
+          <h1 className="text-3xl font-semibold">Simple pricing for every stage</h1>
+          <p className="text-muted-foreground mt-2">Transparent plans in GYD. All include VAT-ready invoicing and core reports.</p>
         </div>
 
-        <div className="rounded-2xl border-2 border-primary bg-card p-6 flex flex-col relative">
-          <span className="absolute -top-3 right-6 rounded-full bg-primary text-primary-foreground text-xs px-2 py-1">Most popular</span>
-          <div className="text-sm font-medium">Business</div>
-          <div className="text-3xl font-semibold mt-1">GYD $9,900<span className="text-base font-normal">/mo</span></div>
-          <ul className="mt-4 space-y-2">
-            <Row>Unlimited users</Row>
-            <Row>Bank import & reconcile</Row>
-            <Row>PAYE & NIS summaries</Row>
-            <Row>Custom sequences & branding</Row>
-            <Row>Priority support</Row>
-          </ul>
-          <Button asChild className="mt-6">
-            <Link href={`/checkout?plan=business`}>Choose Business</Link>
-          </Button>
-          <div className="text-xs text-muted-foreground mt-2">Use code <b>GYA-LAUNCH</b> for 50% off first 2 months.</div>
+        {/* Cards */}
+        <div className="mt-8 grid gap-6 md:grid-cols-4">
+          <div className="rounded-2xl border bg-card p-6 flex flex-col">
+            <div className="text-sm font-medium">Starter</div>
+            <div className="text-3xl font-semibold mt-1">
+              <span className="line-through text-muted-foreground">GYD $3,000</span>
+              <span className="ml-2">Free</span>
+            </div>
+            <div className="text-xs text-muted-foreground">30-day trial</div>
+            <ul className="mt-4 space-y-2">
+              <Row>Up to 2 users</Row>
+              <Row>Invoices & receipts (PDF/email)</Row>
+              <Row>VAT 14% + zero-rated/exempt items</Row>
+              <Row>Trial Balance & P&amp;L</Row>
+              <Row>Email support</Row>
+            </ul>
+            <Button asChild className="mt-6">
+              <Link href={`${next}?plan=starter`}>Start free</Link>
+            </Button>
+          </div>
+
+          <div className="rounded-2xl border-2 border-primary bg-card p-6 flex flex-col relative">
+            <span className="absolute -top-3 right-6 rounded-full bg-primary text-primary-foreground text-xs px-2 py-1">Most popular</span>
+            <div className="text-sm font-medium">Essentials</div>
+            <div className="text-3xl font-semibold mt-1">GYD $5,000<span className="text-base font-normal">/mo</span></div>
+            <ul className="mt-4 space-y-2">
+              <Row>Up to 5 users</Row>
+              <Row>Bank import & reconcile</Row>
+              <Row>PAYE & NIS summaries</Row>
+              <Row>Custom sequences & branding</Row>
+              <Row>Priority support</Row>
+            </ul>
+            <Button asChild className="mt-6">
+              <Link href={`/checkout?plan=essentials`}>Choose Essentials</Link>
+            </Button>
+          </div>
+
+          <div className="rounded-2xl border bg-card p-6 flex flex-col">
+            <div className="text-sm font-medium">Growth</div>
+            <div className="text-3xl font-semibold mt-1">GYD $10,000<span className="text-base font-normal">/mo</span></div>
+            <ul className="mt-4 space-y-2">
+              <Row>Unlimited users</Row>
+              <Row>Advanced approvals & roles</Row>
+              <Row>Inventory tracking</Row>
+              <Row>Multi-currency support</Row>
+              <Row>Priority chat support</Row>
+            </ul>
+            <Button asChild className="mt-6">
+              <Link href={`/checkout?plan=growth`}>Choose Growth</Link>
+            </Button>
+          </div>
+
+          <div className="rounded-2xl border bg-card p-6 flex flex-col">
+            <div className="text-sm font-medium">Pro</div>
+            <div className="text-3xl font-semibold mt-1">Custom pricing</div>
+            <ul className="mt-4 space-y-2">
+              <Row>SLA & onboarding</Row>
+              <Row>Custom integrations & API limits</Row>
+              <Row>Data migration assistance</Row>
+              <Row>Dedicated success manager</Row>
+              <Row>White-glove support</Row>
+            </ul>
+            <Button asChild variant="outline" className="mt-6">
+              <Link href="/contact">Contact sales</Link>
+            </Button>
+          </div>
         </div>
 
-        <div className="rounded-2xl border bg-card p-6 flex flex-col">
-          <div className="text-sm font-medium">Enterprise</div>
-          <div className="text-3xl font-semibold mt-1">Let’s talk</div>
-          <ul className="mt-4 space-y-2">
-            <Row>SLA & onboarding</Row>
-            <Row>Advanced approvals & roles</Row>
-            <Row>Data migration assistance</Row>
-            <Row>Custom integrations & API limits</Row>
-            <Row>Dedicated success manager</Row>
+        {/* Comparison matrix with highlight & next */}
+        <PricingComparison next={next} highlight={highlight} />
+
+        <div className="mt-10 rounded-2xl border p-6 bg-muted/40">
+          <div className="text-sm font-medium">All plans include</div>
+          <ul className="mt-2 grid sm:grid-cols-2 gap-2 text-sm text-muted-foreground">
+            <li>• VAT Summary export for GRA</li>
+            <li>• Multi-org support (tenants)</li>
+            <li>• Secure, role-based access</li>
+            <li>• Email invoicing & PDF receipts</li>
           </ul>
-          <Button asChild variant="outline" className="mt-6">
-            <Link href="/contact">Contact sales</Link>
-          </Button>
         </div>
-      </div>
-
-      {/* Comparison matrix with highlight & next */}
-      <PricingComparison next={next} highlight={highlight} />
-
-      <div className="mt-10 rounded-2xl border p-6 bg-muted/40">
-        <div className="text-sm font-medium">All plans include</div>
-        <ul className="mt-2 grid sm:grid-cols-2 gap-2 text-sm text-muted-foreground">
-          <li>• VAT Summary export for GRA</li>
-          <li>• Multi-org support (tenants)</li>
-          <li>• Secure, role-based access</li>
-          <li>• Email invoicing & PDF receipts</li>
-        </ul>
       </div>
     </section>
   );

--- a/src/components/marketing/FloatingTrialCTA.tsx
+++ b/src/components/marketing/FloatingTrialCTA.tsx
@@ -1,0 +1,13 @@
+"use client";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function FloatingTrialCTA() {
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <Button asChild size="lg">
+        <Link href="/sign-up">Start a free trial</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/marketing/PricingComparison.tsx
+++ b/src/components/marketing/PricingComparison.tsx
@@ -1,24 +1,21 @@
 import { Check, Minus } from "lucide-react";
 
-export type PlanKey = "starter" | "business" | "enterprise";
+export type PlanKey = "starter" | "essentials" | "growth" | "pro";
 
 const basePlans: { key: PlanKey; name: string; price: string }[] = [
-  { key: "starter", name: "Starter", price: "GYD $0 (beta)" },
-  { key: "business", name: "Business", price: "GYD $9,900 / mo" },
-  { key: "enterprise", name: "Enterprise", price: "Let’s talk" },
+  { key: "starter", name: "Starter", price: "GYD $3,000 / mo" },
+  { key: "essentials", name: "Essentials", price: "GYD $5,000 / mo" },
+  { key: "growth", name: "Growth", price: "GYD $10,000 / mo" },
+  { key: "pro", name: "Pro", price: "Custom" },
 ];
 
 const features: { label: string; notes?: string; included: Partial<Record<PlanKey, boolean>> }[] = [
-  { label: "Users", notes: "Starter: up to 2", included: { starter: true, business: true, enterprise: true } },
-  { label: "VAT-ready invoicing", included: { starter: true, business: true, enterprise: true } },
-  { label: "Double-entry ledger", included: { starter: true, business: true, enterprise: true } },
-  { label: "Bank import & reconcile", included: { starter: false, business: true, enterprise: true } },
-  { label: "PAYE & NIS summaries", included: { starter: false, business: true, enterprise: true } },
-  { label: "Custom sequences & branding", included: { starter: false, business: true, enterprise: true } },
-  { label: "Priority support", included: { starter: false, business: true, enterprise: true } },
-  { label: "Advanced approvals & roles", included: { starter: false, business: false, enterprise: true } },
-  { label: "SLA & onboarding", included: { starter: false, business: false, enterprise: true } },
-  { label: "Custom integrations & API limits", included: { starter: false, business: false, enterprise: true } },
+  { label: "Users", notes: "Starter: up to 2", included: { starter: true, essentials: true, growth: true, pro: true } },
+  { label: "VAT-ready invoicing", included: { starter: true, essentials: true, growth: true, pro: true } },
+  { label: "Bank import & reconcile", included: { starter: false, essentials: true, growth: true, pro: true } },
+  { label: "PAYE & NIS summaries", included: { starter: false, essentials: true, growth: true, pro: true } },
+  { label: "Advanced approvals & roles", included: { starter: false, essentials: false, growth: true, pro: true } },
+  { label: "Custom integrations & API limits", included: { starter: false, essentials: false, growth: false, pro: true } },
 ];
 
 function Cell({ ok }: { ok: boolean | undefined }) {
@@ -28,7 +25,7 @@ function Cell({ ok }: { ok: boolean | undefined }) {
 
 export default function PricingComparison({
   next = "/sign-up",
-  highlight = "business",
+  highlight = "essentials",
 }: {
   next?: string;
   highlight?: PlanKey;
@@ -37,7 +34,7 @@ export default function PricingComparison({
   return (
     <div className="mt-12 border rounded-2xl overflow-hidden">
       {/* Header */}
-      <div className="grid grid-cols-4 bg-muted/40">
+      <div className="grid grid-cols-5 bg-muted/40">
         <div className="p-4 text-sm font-medium">Features</div>
         {plans.map((p) => (
           <div key={p.key} className={`p-4 text-sm font-medium ${p.highlight ? "bg-primary/10" : ""}`}>
@@ -50,7 +47,7 @@ export default function PricingComparison({
       {/* Feature rows */}
       <div className="divide-y">
         {features.map((f) => (
-          <div key={f.label} className="grid grid-cols-4 items-center">
+          <div key={f.label} className="grid grid-cols-5 items-center">
             <div className="p-3 text-sm">
               <div>{f.label}</div>
               {f.notes && <div className="text-xs text-muted-foreground">{f.notes}</div>}
@@ -65,14 +62,11 @@ export default function PricingComparison({
       </div>
 
       {/* CTAs respect `next` */}
-      <div className="grid grid-cols-4 bg-muted/30">
+      <div className="grid grid-cols-5 bg-muted/30">
         <div className="p-4 text-sm font-medium">Choose your plan</div>
         {plans.map((p) => {
-          const href =
-            p.key === "enterprise"
-              ? "/contact"
-              : `${next}?plan=${encodeURIComponent(p.key)}`;
-          const label = p.key === "enterprise" ? "Contact sales" : `Choose ${p.name}`;
+          const href = p.key === "pro" ? "/contact" : `${next}?plan=${encodeURIComponent(p.key)}`;
+          const label = p.key === "pro" ? "Contact sales" : `Choose ${p.name}`;
           return (
             <div key={p.key} className={`p-4 ${p.highlight ? "bg-primary/10" : ""}`}>
               <a href={href} className="inline-flex items-center justify-center w-full rounded-md border px-3 py-2 text-sm">


### PR DESCRIPTION
## Summary
- redesign pricing page with four-tier packages and updated comparison
- add floating "Start a free trial" button across marketing pages

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bddf03714483298bcf7c3492394825