### PR TITLE
Add reversible media-text marketing section

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lucide-react": "^0.542.0",
     "mailparser": "^3.7.4",
     "gray-matter": "^4.0.3",
-    "lucide-react": "^0.542.0",
     "marked": "^16.2.1",
 
     "mjml": "^4.15.3",
@@ -42,8 +41,8 @@
     "react-fast-marquee": "^1.6.5",
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
-    "zod": "^4.1.5"
-    "yaml": "^2.8.1",
+    "zod": "^4.1.5",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -4,6 +4,7 @@ import HeroClient from "@/components/marketing/HeroClient";
 import TestimonialsSection from "@/components/marketing/TestimonialsSection";
 import PricingSection from "@/components/marketing/PricingSection";
 import FAQSection from "@/components/marketing/FAQSection";
+import MediaBullets from "@/components/marketing/MediaBullets";
 import { chooseNOnce } from "@/lib/randomize";
 import { heroCopy, HeroKey } from "@/lib/copy/imageCopy";
 
@@ -47,11 +48,26 @@ export default async function HomePage() {
               </Link>
             ))}
           </div>
-        </div>
-      </section>
+          </div>
+        </section>
 
-      {/* HERO 2 */}
-      <section className="border-b">
+        {/* FEATURE DEMO */}
+        <section className="border-b">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <MediaBullets
+            mediaSrc="/feature-demo.webp"
+            bullets={[
+              "Fast onboarding with guided setup.",
+              "Intuitive dashboard for quick insights.",
+              "Secure cloud backups and access anywhere.",
+            ]}
+            reverse
+          />
+        </div>
+        </section>
+
+        {/* HERO 2 */}
+        <section className="border-b">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <HeroClient
             itemId={hero2Key}
@@ -61,7 +77,7 @@ export default async function HomePage() {
             imgSrc={`/photos/landing/${hero2Key}.webp`}
           />
         </div>
-      </section>
+        </section>
 
       {/* WHY LOCAL */}
       <section id="why-local" className="border-t">

--- a/src/components/marketing/MediaBullets.tsx
+++ b/src/components/marketing/MediaBullets.tsx
@@ -1,0 +1,47 @@
+import Image from "next/image";
+
+export type MediaBulletsProps = {
+  mediaSrc: string;
+  bullets: string[];
+  reverse?: boolean;
+};
+
+export default function MediaBullets({ mediaSrc, bullets, reverse }: MediaBulletsProps) {
+  const isVideo = mediaSrc.endsWith(".mp4") || mediaSrc.endsWith(".webm");
+  return (
+    <div className="relative grid items-center gap-10 py-16 md:grid-cols-2">
+      <div className={reverse ? "md:order-2" : undefined}>
+        <ul className="list-disc space-y-3 pl-5 text-muted-foreground">
+          {bullets.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
+      <div
+        className={`relative aspect-[16/10] w-full overflow-hidden rounded-2xl border ${
+          reverse ? "md:order-1" : ""
+        }`}
+      >
+        {isVideo ? (
+          <video
+            src={mediaSrc}
+            className="h-full w-full object-cover"
+            autoPlay
+            loop
+            muted
+            playsInline
+          />
+        ) : (
+          <Image
+            src={mediaSrc}
+            alt=""
+            fill
+            sizes="(min-width: 768px) 50vw, 100vw"
+            className="object-cover"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- introduce `MediaBullets` component for showcasing media alongside a bullet list with optional reversed layout
- add feature demo section on marketing homepage leveraging the component
- remove committed demo media asset; expect `public/feature-demo.webp` to be supplied separately
- fix malformed `package.json` to enable linting

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bde76dd4448329a13753aa0f042005