### PR TITLE
feat: add compliance hero and rotate marketing heroes

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 import HeroClient from "@/components/marketing/HeroClient";
 import TestimonialsSection from "@/components/marketing/TestimonialsSection";
@@ -10,9 +9,14 @@ import { heroCopy, HeroKey } from "@/lib/copy/imageCopy";
 
 export default async function HomePage() {
   const keys = Object.keys(heroCopy) as HeroKey[];
-  const [hero1Key, hero2Key] = await chooseNOnce("hb_home_heroes", keys, 2);
+  const [hero1Key, hero2Key, hero3Key] = await chooseNOnce(
+    "hb_home_heroes",
+    keys,
+    3
+  );
   const hero1 = heroCopy[hero1Key];
   const hero2 = heroCopy[hero2Key];
+  const hero3 = heroCopy[hero3Key];
 
   return (
     <div>
@@ -79,31 +83,16 @@ export default async function HomePage() {
         </div>
         </section>
 
-      {/* WHY LOCAL */}
+      {/* HERO 3 */}
       <section id="why-local" className="border-t">
-        <div className="mx-auto grid max-w-7xl grid-cols-1 items-center gap-10 px-4 py-16 sm:px-6 md:grid-cols-2 lg:px-8">
-          <div>
-            <h2 className="text-2xl font-bold">Why Choose Local?</h2>
-            <p className="mt-4 text-muted-foreground">
-              Think local, act local — utilize accounting software that understands and meets the demands of Guyanese businesses.
-            </p>
-            <div className="mt-6">
-              <Link
-                href="#pricing"
-                className="rounded-lg bg-emerald-600 px-5 py-3 text-white shadow hover:bg-emerald-700"
-              >
-                Get Started
-              </Link>
-            </div>
-          </div>
-          <div className="relative h-[300px] w-full rounded-2xl bg-neutral-100 dark:bg-neutral-800">
-            <Image
-              src="/photos/landing/why-placeholder.jpg"
-              alt="Why Local"
-              fill
-              className="rounded-2xl object-cover"
-            />
-          </div>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <HeroClient
+            itemId={hero3Key}
+            headline={hero3.headline}
+            story={hero3.story}
+            ctas={hero3.ctas}
+            imgSrc={`/photos/landing/${hero3Key}.webp`}
+          />
         </div>
       </section>
 

--- a/src/lib/copy/imageCopy.ts
+++ b/src/lib/copy/imageCopy.ts
@@ -80,6 +80,15 @@ export const heroCopy = {
       secondary: { label: "See features", href: "/features" },
     },
   },
+  compliance: {
+    headline: "Built for Guyana & Caribbean compliance",
+    story:
+      "From VAT and PAYE to NIS, heroBooks keeps regional rules baked in so your books stay audit‑ready across borders.",
+    ctas: {
+      primary: { label: "Get started", href: "/get-started" },
+      secondary: { label: "See compliance", href: "/features#compliance" },
+    },
+  },
 } as const;
 
 export const testimonialCopy = {


### PR DESCRIPTION
## Summary
- add compliance-focused hero copy for Guyana and Caribbean rules
- rotate three hero sections on marketing homepage and replace static why-local block with third hero while preserving its anchor

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdea92783883298fd0ed584fbfe368