### PR TITLE
feat: random testimonial cards

### DIFF
--- a/src/components/marketing/TestimonialsClient.tsx
+++ b/src/components/marketing/TestimonialsClient.tsx
@@ -1,0 +1,107 @@
+"use client";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { recordFeatureImpression } from "@/lib/telemetry";
+import { getStoryById } from "@/lib/stories";
+import ComingSoonOverlay from "@/components/marketing/ComingSoonOverlay";
+import { testimonialCopy } from "@/lib/copy/imageCopy";
+
+const headings = [
+  "Trusted by local professionals",
+  "Trusted by local trades",
+  "Trusted by growing businesses in Guyana",
+];
+
+export type TestimonialsClientProps = {
+  heading?: string;
+  entries: [string, (typeof testimonialCopy)[string]][];
+};
+
+export default function TestimonialsClient({ heading, entries }: TestimonialsClientProps) {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const [title, setTitle] = useState(heading ?? headings[0]);
+
+  useEffect(() => {
+    if (!heading) {
+      setTitle(headings[Math.floor(Math.random() * headings.length)]);
+    }
+  }, [heading]);
+
+  useEffect(() => {
+    recordFeatureImpression({
+      feature: "testimonial_impression",
+      meta: {
+        location: "marketing_testimonials",
+        item_ids: entries.map(([id]) => id),
+      },
+    });
+  }, [entries]);
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold text-center md:text-left">{title}</h2>
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+        {entries.map(([id, t]) => {
+          const story = getStoryById(t.storyId);
+          const imgSrc = `/photos/testimonials/${id}.webp`;
+          const isOpen = open[id];
+          return (
+            <div
+              key={id}
+              className="flex cursor-pointer flex-col gap-2 rounded-xl border p-4 bg-muted/30 text-sm"
+              onClick={() => {
+                const next = { ...open, [id]: !isOpen };
+                setOpen(next);
+                if (!isOpen) {
+                  recordFeatureImpression({
+                    feature: "case_study_open",
+                    meta: { story_id: t.storyId, placement: "testimonials_inline" },
+                  });
+                }
+              }}
+            >
+              <div className="flex gap-3">
+                <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg border">
+                  <Image src={imgSrc} alt={t.name} fill className="object-cover" />
+                </div>
+                <p className="leading-snug line-clamp-3">“{t.quote}”</p>
+              </div>
+              {isOpen && story && (
+                <div className="mt-2 flex flex-col gap-2">
+                  {story.summary_lines.map((line) => (
+                    <p key={line}>{line}</p>
+                  ))}
+                  {story.consent_obtained ? (
+                    <a
+                      href={story.try_setup_href}
+                      className="mt-2 inline-block font-medium underline"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        recordFeatureImpression({
+                          feature: "case_study_try_setup_click",
+                          meta: { story_id: t.storyId, href: story.try_setup_href },
+                        });
+                      }}
+                    >
+                      Try this setup
+                    </a>
+                  ) : (
+                    <ComingSoonOverlay story={story} trySetup />
+                  )}
+                </div>
+              )}
+              <div className="mt-auto pt-2 text-xs text-muted-foreground">
+                <div className="font-medium text-foreground">{t.name}</div>
+                <div>{t.role}</div>
+                <div className="mt-1">{t.since}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-8 text-center text-xs text-muted-foreground">
+        Real customers. Real operations. Photos edited for clarity.
+      </p>
+    </>
+  );
+}

--- a/src/components/marketing/TestimonialsSection.tsx
+++ b/src/components/marketing/TestimonialsSection.tsx
@@ -1,11 +1,6 @@
-"use client";
-
-import Image from "next/image";
-import { useEffect, useState } from "react";
+import TestimonialsClient from "./TestimonialsClient";
+import { chooseNOnce } from "@/lib/randomize";
 import { testimonialCopy } from "@/lib/copy/imageCopy";
-import { recordFeatureImpression } from "@/lib/telemetry";
-import { getStoryById } from "@/lib/stories";
-import ComingSoonOverlay from "@/components/marketing/ComingSoonOverlay";
 
 const headings = [
   "Trusted by local professionals",
@@ -13,94 +8,16 @@ const headings = [
   "Trusted by growing businesses in Guyana",
 ];
 
-export default function TestimonialsSection() {
-  const [heading, setHeading] = useState(headings[0]);
+export default async function TestimonialsSection() {
   const entries = Object.entries(testimonialCopy);
-  const [open, setOpen] = useState<Record<string, boolean>>({});
-
-  useEffect(() => {
-    setHeading(headings[Math.floor(Math.random() * headings.length)]);
-  }, []);
-
-  useEffect(() => {
-    recordFeatureImpression({
-      feature: "testimonial_impression",
-      meta: {
-        location: "marketing_testimonials",
-        item_ids: entries.map(([id]) => id),
-      },
-    });
-  }, [entries]);
+  const selected = await chooseNOnce("hb_testimonials", entries, 3);
+  const heading = headings[Math.floor(Math.random() * headings.length)];
 
   return (
     <section id="testimonials" className="border-t">
       <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-        <h2 className="text-2xl font-bold text-center md:text-left">{heading}</h2>
-        <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
-          {entries.map(([id, t]) => {
-            const story = getStoryById(t.storyId);
-            const imgSrc = `/photos/testimonials/${id}.webp`;
-            const isOpen = open[id];
-            return (
-              <div key={id} className="rounded-2xl border p-6 flex flex-col gap-4 bg-muted/30">
-                <div className="relative h-24 w-24 overflow-hidden rounded-xl border">
-                  <Image src={imgSrc} alt={t.name} fill className="object-cover" />
-                </div>
-                <p className="text-sm leading-snug">“{t.quote}”</p>
-                <p className="text-xs">{t.teaser}</p>
-                <button
-                  className="mt-2 text-sm font-medium underline"
-                  onClick={() => {
-                    const next = { ...open, [id]: !isOpen };
-                    setOpen(next);
-                    if (!isOpen) {
-                      recordFeatureImpression({
-                        feature: "case_study_open",
-                        meta: { story_id: t.storyId, placement: "testimonials_inline" },
-                      });
-                    }
-                  }}
-                >
-                  See how heroBooks works for them
-                </button>
-                {isOpen && story && (
-                  <div className="relative mt-4 flex flex-col gap-2 text-sm">
-                    {story.summary_lines.map((line) => (
-                      <p key={line}>{line}</p>
-                    ))}
-                    {story.consent_obtained && (
-                      <a
-                        href={story.try_setup_href}
-                        className="mt-2 inline-block text-sm font-medium underline"
-                        onClick={() =>
-                          recordFeatureImpression({
-                            feature: "case_study_try_setup_click",
-                            meta: { story_id: t.storyId, href: story.try_setup_href },
-                          })
-                        }
-                      >
-                        Try this setup
-                      </a>
-                    )}
-                    {!story.consent_obtained && (
-                      <ComingSoonOverlay story={story} trySetup />
-                    )}
-                  </div>
-                )}
-                <div className="mt-auto text-xs text-muted-foreground">
-                  <div className="font-medium text-foreground">{t.name}</div>
-                  <div>{t.role}</div>
-                  <div className="mt-1">{t.since}</div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-        <p className="mt-8 text-center text-xs text-muted-foreground">
-          Real customers. Real operations. Photos edited for clarity.
-        </p>
+        <TestimonialsClient heading={heading} entries={selected} />
       </div>
     </section>
   );
 }
-


### PR DESCRIPTION
## Summary
- randomize testimonial selection using chooseNOnce
- show compact testimonial cards that expand with detailed stories
- track case study opens for telemetry

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdebb4c9c4832985e70814264f2bbf