### PR TITLE
Use default button styling for floating trial CTA

### DIFF
--- a/src/components/marketing/FloatingTrialCTA.tsx
+++ b/src/components/marketing/FloatingTrialCTA.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 export default function FloatingTrialCTA() {
   return (
     <div className="fixed bottom-4 right-4 z-50">
-      <Button asChild size="lg">
+      <Button asChild>
         <Link href="/sign-up">Start a free trial</Link>
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- Align floating trial CTA with MarketingHeader by using default `<Button>` styling.
- Checked z-index positioning against the header to avoid overlap.
- Confirmed FeaturesRandom has no button needing updates.

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bdf02ec7148329a415f04739d6547d