### PR TITLE
fix missing TestimonialKey import

### DIFF
--- a/src/components/marketing/TestimonialsClient.tsx
+++ b/src/components/marketing/TestimonialsClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { recordFeatureImpression } from "@/lib/telemetry";
 import { getStoryById } from "@/lib/stories";
 import ComingSoonOverlay from "@/components/marketing/ComingSoonOverlay";
-import { testimonialCopy } from "@/lib/copy/imageCopy";
+import { testimonialCopy, TestimonialKey } from "@/lib/copy/imageCopy";
 import { testimonialImages } from "@/lib/images";
 
 const headings = [


### PR DESCRIPTION
## Summary
- import `TestimonialKey` into `TestimonialsClient` to satisfy type references during build

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68be1b8003248329a6f55bec0950bd58