### PR TITLE
Fix missing section anchors and placeholder links

### DIFF
--- a/src/app/(app)/settings/organization/page.tsx
+++ b/src/app/(app)/settings/organization/page.tsx
@@ -4,7 +4,9 @@ export default function OrganizationSettingsPage() {
   return (
     <div className="space-y-6 text-sm">
       <div>Organization — TODO: legal name, address, VAT, sequences.</div>
-      <TaxesPanel />
+      <section id="taxes">
+        <TaxesPanel />
+      </section>
     </div>
   );
 }

--- a/src/components/StickyNav.tsx
+++ b/src/components/StickyNav.tsx
@@ -111,13 +111,13 @@ export default function StickyNav() {
 
         <div className="ml-auto flex items-center gap-2">
           <SearchExpand />
-          <Link
-            href="#"
+          <button
+            onClick={onNavClick("Notifications", "/notifications")}
             className="p-2 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800"
             aria-label="Notifications"
           >
             <Bell className="h-5 w-5" />
-          </Link>
+          </button>
           <div className="relative">
             <button
               className="flex items-center gap-1 rounded-md px-2 py-1.5 hover:bg-neutral-100 dark:hover:bg-neutral-800"

--- a/src/components/marketing/PricingSection.tsx
+++ b/src/components/marketing/PricingSection.tsx
@@ -66,6 +66,7 @@ export default function PricingSection() {
         <div className="mt-8 grid gap-6 sm:grid-cols-2 md:grid-cols-3">
           {plans.map((plan) => (
             <div
+              id={plan.id}
               key={plan.id}
               className={`relative flex flex-col rounded-2xl border bg-background p-6 ${
                 plan.featured ? "scale-105 border-emerald-500 shadow-lg" : ""


### PR DESCRIPTION
## Summary
- ensure notifications icon uses button instead of dead `#` link
- add missing section IDs so pricing and settings anchors work

## Testing
- `pnpm install`
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be1cd8479c8329b3579385790bd3a8