### PR TITLE
Refine marketing UI and footer styling

### DIFF
--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -4,6 +4,7 @@ import SectionCard from "@/components/UX/SectionCard";
 import Page from "@/components/UX/Page";
 import { asCssVars } from "@/lib/brand-tokens";
 import aboutCopy from "@/lib/copy/about-herobooks";
+import { Button } from "@/components/ui/button";
 
 export const metadata = {
   title: "About Us — heroBooks",
@@ -26,9 +27,13 @@ export default function AboutPage() {
           </ul>
           <div className="mt-4 flex flex-wrap gap-2">
             {mission.ctas.map((c) => (
-              <Link key={c.href} href={c.href} className={c.type === "primary" ? "rounded-xl bg-[var(--brand)] px-4 py-2 font-semibold text-white" : "rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-4 py-2 font-semibold text-[var(--brand)]"}>
-                {c.label}
-              </Link>
+              <Button
+                key={c.href}
+                asChild
+                variant={c.type === "primary" ? "default" : "outline"}
+              >
+                <Link href={c.href}>{c.label}</Link>
+              </Button>
             ))}
           </div>
         </SectionCard>
@@ -67,7 +72,9 @@ export default function AboutPage() {
             ))}
           </div>
           <div className="mt-4 text-center">
-            <Link href="/contact?subject=press" className="inline-block rounded-xl bg-black px-4 py-2 font-semibold text-white">→ {leadershipHighlights.cta}</Link>
+            <Button asChild>
+              <Link href="/contact?subject=press">→ {leadershipHighlights.cta}</Link>
+            </Button>
           </div>
         </SectionCard>
 
@@ -87,7 +94,9 @@ export default function AboutPage() {
             <h3 className="mt-4 text-lg font-semibold">{standards.corrections.title}</h3>
             <p className="text-[15px] text-slate-700">{standards.corrections.text}</p>
             <div className="mt-3">
-              <Link href="/contact?subject=support" className="rounded-xl border border-[var(--brand-light)] bg-[var(--brand-lighter)] px-3 py-2 text-sm font-semibold text-[var(--brand)]">{standards.corrections.linkText}</Link>
+              <Button asChild variant="outline" size="sm">
+                <Link href="/contact?subject=support">{standards.corrections.linkText}</Link>
+              </Button>
             </div>
           </SectionCard>
           <SectionCard id="about-reach-us">
@@ -96,7 +105,9 @@ export default function AboutPage() {
             <ul className="mt-4 space-y-4">
               {reachUs.contacts.map((c) => (
                 <li key={c.token} className="list-none">
-                  <Link href={`/contact?subject=${c.token}`} className="rounded-xl bg-black px-4 py-2 text-sm font-semibold text-white">{c.label}</Link>
+                  <Button asChild size="sm">
+                    <Link href={`/contact?subject=${c.token}`}>{c.label}</Link>
+                  </Button>
                   <p className="mt-1 text-sm text-slate-600">{c.desc}</p>
                 </li>
               ))}
@@ -105,7 +116,6 @@ export default function AboutPage() {
           </SectionCard>
         </div>
       </Page>
-      <footer className="px-4 pb-8 text-center text-slate-500">© {new Date().getFullYear()} heroBooks — All rights reserved.</footer>
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,11 +10,11 @@ export default function Footer({ authenticated = false }: FooterProps) {
     ? ({ target: "_blank", rel: "noopener noreferrer" } as const)
     : {};
   return (
-    <footer className="border-t bg-background text-sm">
+    <footer className="border-t bg-foreground text-background text-sm">
       <div className="container mx-auto grid gap-8 px-4 py-10 sm:grid-cols-5">
         <div>
           <div className="mb-2 font-semibold">Product</div>
-          <ul className="space-y-1 text-muted-foreground">
+          <ul className="space-y-1 text-background/70">
             <li>
               <Link href="/#features" {...linkProps} className="hover:underline">
                 Features
@@ -48,7 +48,7 @@ export default function Footer({ authenticated = false }: FooterProps) {
         </div>
         <div>
           <div className="mb-2 font-semibold">Company</div>
-          <ul className="space-y-1 text-muted-foreground">
+          <ul className="space-y-1 text-background/70">
             <li>
               <Link href="/about" {...linkProps} className="hover:underline">
                 About
@@ -73,7 +73,7 @@ export default function Footer({ authenticated = false }: FooterProps) {
         </div>
         <div>
           <div className="mb-2 font-semibold">Resources</div>
-          <ul className="space-y-1 text-muted-foreground">
+          <ul className="space-y-1 text-background/70">
             <li>
               <Link href="/docs" {...linkProps} className="hover:underline">
                 Docs/Guides
@@ -98,7 +98,7 @@ export default function Footer({ authenticated = false }: FooterProps) {
         </div>
         <div>
           <div className="mb-2 font-semibold">Legal</div>
-          <ul className="space-y-1 text-muted-foreground">
+          <ul className="space-y-1 text-background/70">
             <li>
               <Link
                 href="/legal/privacy"
@@ -139,7 +139,7 @@ export default function Footer({ authenticated = false }: FooterProps) {
         </div>
         <div>
           <div className="mb-2 font-semibold">Contact</div>
-          <ul className="space-y-1 text-muted-foreground">
+          <ul className="space-y-1 text-background/70">
             <li>
               <a href="mailto:support@herobooks.gy" className="hover:underline">
                 support@herobooks.gy
@@ -149,7 +149,7 @@ export default function Footer({ authenticated = false }: FooterProps) {
           </ul>
         </div>
       </div>
-      <div className="border-t py-4 text-center text-xs text-muted-foreground">
+      <div className="border-t border-background/20 py-4 text-center text-xs text-background/70">
         © {year} heroBooks. Built for businesses in Guyana.
       </div>
     </footer>

--- a/src/components/marketing/FAQSection.tsx
+++ b/src/components/marketing/FAQSection.tsx
@@ -24,39 +24,17 @@ export default function FAQSection() {
       q: "Does payroll include PAYE and NIS?",
       a: "Yes—enable payroll basics, set thresholds, and we calculate PAYE/NIS on each run.",
     },
-    {
-      q: "What reports are included?",
-      a: "Profit & Loss, Balance Sheet, Sales & Purchases, VAT summary, and more depending on plan.",
-    },
-    {
-      q: "Can I switch plans later?",
-      a: "Anytime. Your data stays intact when upgrading or downgrading.",
-    },
-    {
-      q: "How does the demo work?",
-      a: "Explore with sample data. You can reset or switch to your live org when ready.",
-    },
-    {
-      q: "Do you have an API?",
-      a: "Yes—Pro includes an API to plug into dealer or service workflows.",
-    },
-    {
-      q: "Is my data secure?",
-      a: "We use modern encryption, role-based access, and audit logging. See our Security page.",
-    },
-    {
-      q: "How do I get support?",
-      a: "Use the in-app Assistance Sidebar, email support, or request a callback for Pro.",
-    },
   ];
   return (
     <section id="faq" className="border-t">
-      <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
         <h2 className="text-2xl font-bold">Frequently asked questions</h2>
-        <div className="mt-6 space-y-4">
+        <div className="mt-6 space-y-3">
           {faqs.map((item) => (
-            <details key={item.q} className="group rounded-2xl border p-4">
-              <summary className="cursor-pointer list-none font-medium">{item.q}</summary>
+            <details key={item.q} className="group rounded-2xl border p-3">
+              <summary className="cursor-pointer list-none font-medium">
+                {item.q}
+              </summary>
               <p className="mt-2 text-sm text-muted-foreground">{item.a}</p>
             </details>
           ))}

--- a/src/components/marketing/MarketingHeader.tsx
+++ b/src/components/marketing/MarketingHeader.tsx
@@ -2,11 +2,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { useSession } from "next-auth/react";
 import { Button } from "@/components/ui/button";
-import SearchExpand from "@/components/SearchExpand";
-import NotificationsBell from "@/components/topbar/NotificationsBell";
-import UserMenu from "@/components/topbar/UserMenu";
 
 const nav = [
   { href: "/features", label: "Features" },
@@ -17,15 +13,21 @@ const nav = [
 
 export default function MarketingHeader() {
   const pathname = usePathname();
-  const { data: session } = useSession();
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background/70 backdrop-blur">
-      <div className="container mx-auto h-14 px-4 flex items-center justify-between">
-        <Link href="/" className="flex items-center gap-2">
-          <Image src="/logos/heroBooks mini Color.png" alt="heroBooks" width={24} height={24} />
-          <span className="font-semibold tracking-tight">heroBooks</span>
-        </Link>
-        <nav className="hidden md:flex items-center gap-6 text-sm">
+      <div className="container mx-auto flex h-14 items-center">
+        <div className="flex flex-1 items-center">
+          <Link href="/" className="flex items-center gap-2">
+            <Image
+              src="/logos/heroBooks mini Color.png"
+              alt="heroBooks"
+              width={24}
+              height={24}
+            />
+            <span className="font-semibold tracking-tight">heroBooks</span>
+          </Link>
+        </div>
+        <nav className="hidden flex-1 items-center justify-center gap-6 text-sm md:flex">
           {nav.map((n) => (
             <Link
               key={n.href}
@@ -40,31 +42,22 @@ export default function MarketingHeader() {
             </Link>
           ))}
         </nav>
-        <div className="flex items-center gap-2">
-          {!session ? (
-            <>
-              <Link
-                href="/sign-in"
-                className="text-sm px-3 py-1.5 rounded-md hover:bg-muted"
-              >
-                Sign in
-              </Link>
-              <Button asChild>
-                <Link href="/pricing#starter">Start free trial</Link>
-              </Button>
-            </>
-          ) : (
-            <>
-              <SearchExpand />
-              <NotificationsBell />
-              <UserMenu />
-            </>
-          )}
+        <div className="flex flex-1 items-center justify-end gap-2">
+          <Link
+            href="/sign-in"
+            className="rounded-md px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Sign in
+          </Link>
+          <Button asChild>
+            <Link href="/pricing#starter">Start free trial</Link>
+          </Button>
         </div>
       </div>
-      <div className="w-full bg-primary/10 border-t">
-        <div className="container mx-auto px-4 py-2 text-xs sm:text-sm text-center">
-          🎉 Early adopters: 2 months <b>50% off</b> on Business plan. Use code <b>GYA-LAUNCH</b>.
+      <div className="w-full border-t bg-primary/10">
+        <div className="container mx-auto px-4 py-2 text-center text-xs sm:text-sm">
+          🎉 Early adopters: 2 months <b>50% off</b> on Business plan. Use code
+          <b> GYA-LAUNCH</b>.
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Center navigation and simplify marketing header to always show sign in and trial actions
- Darken global footer and standardize link behavior for authenticated users
- Trim and restyle FAQ section and unify About page CTAs using shared button component

## Testing
- `pnpm install`
- `pnpm build`
- `npx next start`

------
https://chatgpt.com/codex/tasks/task_e_68be2c3f8a7c8329883fcbff5dd08475