### PR TITLE
feat: add feature highlight component

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -4,6 +4,7 @@ import TestimonialsSection from "@/components/marketing/TestimonialsSection";
 import PricingSection from "@/components/marketing/PricingSection";
 import FAQSection from "@/components/marketing/FAQSection";
 import MediaBullets from "@/components/marketing/MediaBullets";
+import FeatureHighlight from "@/components/marketing/FeatureHighlight";
 import { chooseNOnce } from "@/lib/randomize";
 import { heroCopy, HeroKey } from "@/lib/copy/imageCopy";
 import { heroImages } from "@/lib/images";
@@ -37,6 +38,8 @@ export default async function HomePage() {
           />
         </div>
       </section>
+
+      <FeatureHighlight />
 
       {/* FEATURES */}
       <section id="features" className="border-b">

--- a/src/components/marketing/FeatureHighlight.tsx
+++ b/src/components/marketing/FeatureHighlight.tsx
@@ -1,0 +1,38 @@
+"use client";
+import Image from "next/image";
+
+export default function FeatureHighlight() {
+  return (
+    <section
+      aria-labelledby="feature-highlight-title"
+      className="w-full mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8 md:py-12"
+    >
+      <div className="flex items-center justify-between gap-6 mb-4">
+        <div>
+          <h2
+            id="feature-highlight-title"
+            className="text-2xl md:text-3xl font-semibold tracking-tight"
+          >
+            Feature Highlights
+          </h2>
+          <p className="text-sm md:text-base text-muted-foreground">
+            A quick look at what heroBooks does best.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-2xl overflow-hidden shadow-sm ring-1 ring-black/5 bg-background">
+        <Image
+          src="/landing/feature-highlight-fast.webp"
+          alt="heroBooks feature highlights: Smart Invoices, Instant Reports, Bank Reconciliation, and Tax Compliance."
+          width={1024}
+          height={1024}
+          priority={false}
+          loading="lazy"
+          unoptimized
+          className="w-full h-auto block"
+        />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add feature highlight component showcasing heroBooks capabilities
- display feature highlight below the landing page hero

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68be3222db848329a148eda380ab83f3