### PR TITLE
chore: rename global stylesheet and use Tailwind import

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,4 +1,4 @@
-import "../globals.css";
+import "../global.css";
 import Sidebar from "@/components/nav/Sidebar";
 import Topbar from "@/components/topbar/Topbar";
 import AssistSidebar from "@/components/app/AssistSidebar";

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,4 +1,4 @@
-import "../globals.css";
+import "../global.css";
 import MarketingHeader from "@/components/marketing/MarketingHeader";
 import Footer from "@/components/Footer";
 import FloatingTrialCTA from "@/components/marketing/FloatingTrialCTA";

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 /* Design tokens (shadcn-style) */
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import "./globals.css";
+import "./global.css";
 import type { Metadata } from "next";
 import { ReactNode } from "react";
 import { Inter } from "next/font/google";


### PR DESCRIPTION
## Summary
- rename `globals.css` to `global.css`
- replace Tailwind layer directives with a single `@import "tailwindcss"`
- update layout imports to the new stylesheet name

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68be61e617f083298d1dc9dd58b82b8b