### PR TITLE
Revamp marketing pages and layout

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
-export default function LoginPage() {
+export default function LegacyLoginRedirect() {
+  // Hard redirect any legacy /login usages to the canonical sign-in
   redirect("/sign-in");
 }
 

--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -1,147 +1,33 @@
-import Link from "next/link";
-import Image from "next/image";
-import type { Metadata } from "next";
-import type { CSSProperties } from "react";
-import SectionCard from "@/components/UX/SectionCard";
-import Page from "@/components/UX/Page";
-import { asCssVars } from "@/lib/brand-tokens";
-import aboutCopy from "@/lib/copy/about-herobooks";
-import { Button } from "@/components/ui/button";
-
-export const metadata: Metadata = {
-  title: "About Us - heroBooks",
-  description:
-    "Learn about heroBooks' mission, values, and the team behind local-first accounting.",
-};
+import Image from "next/image"
+import Page from "@/components/UX/Page"
+import SectionCard from "@/components/UX/SectionCard"
 
 export default function AboutPage() {
-  const brandVars = asCssVars();
-  const { hero, mission, whoWeAre, values, leadershipHighlights, standards, reachUs } = aboutCopy;
-
   return (
-    <div style={brandVars as CSSProperties}>
-      <Page title={hero.title} subtitle={hero.subtitle}>
-        <SectionCard id="about-mission" className="mb-8">
-          <span
-            className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold"
-            style={{ background: "var(--brand-tag-bg)", color: "var(--brand-tag-text)" }}
-          >
-            {mission.tag}
-          </span>
-          <h2 className="mt-2 text-2xl font-bold">{mission.headline}</h2>
-          <p className="mt-1 text-[15px] text-slate-600">{mission.body}</p>
-          <ul className="mt-3 space-y-1 text-[15px] text-slate-700">
-            {mission.bullets.map((b) => (
-              <li key={b}>{b}</li>
-            ))}
-          </ul>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {mission.ctas.map((c) => (
-              <Button key={c.href} asChild variant={c.type === "primary" ? "default" : "outline"}>
-                <Link href={c.href}>{c.label}</Link>
-              </Button>
-            ))}
-          </div>
-        </SectionCard>
-
-        <div className="mb-8 grid gap-8 lg:grid-cols-2">
-          <SectionCard id="about-who-we-are">
-            <h2 className="text-2xl font-bold">{whoWeAre.title}</h2>
-            {whoWeAre.paragraphs.map((p) => (
-              <p key={p} className="mt-2 text-[15px] text-slate-700">
-                {p}
-              </p>
-            ))}
-          </SectionCard>
-          <SectionCard id="about-values">
-            <h2 className="text-2xl font-bold">{values.title}</h2>
-            <p className="mt-2 text-[15px] text-slate-700">{values.subtitle}</p>
-            <div className="mt-4 grid gap-4 sm:grid-cols-3">
-              {values.items.map((v) => (
-                <div key={v.t} className="rounded-2xl bg-white p-6 shadow">
-                  <strong className="block">{v.t}</strong>
-                  <p className="mt-1 text-[15px] text-slate-700">{v.d}</p>
-                </div>
-              ))}
-            </div>
-          </SectionCard>
+    <Page title="About heroBooks" subtitle="Simple, local-first accounting—built in Guyana, ready for the Caribbean.">
+      <SectionCard>
+        <div className="space-y-6">
+          <h2 className="text-2xl font-semibold">Make bookkeeping effortless for local businesses</h2>
+          <p className="text-muted-foreground">We’re building modern accounting that understands VAT, PAYE, NIS, and the realities of running a small business in Guyana—with an eye toward the broader Caribbean.</p>
         </div>
-
-        <SectionCard id="about-leadership" className="mb-8">
-          <span
-            className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold"
-            style={{ background: "var(--brand-tag-bg)", color: "var(--brand-tag-text)" }}
-          >
-            {leadershipHighlights.tag}
-          </span>
-          <h2 className="mt-2 text-2xl font-bold">{leadershipHighlights.title}</h2>
-          <p className="mt-1 text-[15px] text-slate-700">{leadershipHighlights.subtitle}</p>
-          <div className="mt-4 grid gap-6 sm:grid-cols-3">
-            {leadershipHighlights.people.map((p) => (
-              <article key={p.name} className="text-center">
-                <Image
-                  src={p.photo}
-                  alt={p.name}
-                  width={96}
-                  height={96}
-                  className="mx-auto rounded-full object-cover"
-                />
-                <h3 className="mt-3 text-base font-semibold">{p.name}</h3>
-                <p className="m-0 text-sm text-slate-600">{p.title}</p>
-                <p className="mt-2 text-[15px] text-slate-700">{p.bio}</p>
-              </article>
-            ))}
-          </div>
-          <div className="mt-4 text-center">
-            <Button asChild>
-              <Link href="/contact?subject=press">{leadershipHighlights.cta}</Link>
-            </Button>
-          </div>
-        </SectionCard>
-
-        <div className="grid gap-8 lg:grid-cols-2">
-          <SectionCard id="about-standards">
-            <h2 className="text-2xl font-bold">{standards.title}</h2>
-            <p className="mt-2 text-[15px] text-slate-700">{standards.intro}</p>
-            <ul className="mt-3 list-disc space-y-1 pl-5 text-[15px] text-slate-700">
-              {standards.bullets.map((b: { label: string; text: string }) => (
-                <li key={b.label}>
-                  <strong>{b.label}:</strong> {b.text}
-                </li>
-              ))}
-            </ul>
-            <h3 className="mt-4 text-lg font-semibold">{standards.factCheck.title}</h3>
-            <ol className="list-decimal space-y-2 pl-5 text-[15px] text-slate-700">
-              {standards.factCheck.steps.map((s: string) => (
-                <li key={s}>{s}</li>
-              ))}
-            </ol>
-            <h3 className="mt-4 text-lg font-semibold">{standards.corrections.title}</h3>
-            <p className="text-[15px] text-slate-700">{standards.corrections.text}</p>
-            <div className="mt-3">
-              <Button asChild variant="outline" size="sm">
-                <Link href="/contact?subject=support">{standards.corrections.linkText}</Link>
-              </Button>
+      </SectionCard>
+      <SectionCard>
+        <h2 className="text-2xl font-semibold">Leadership</h2>
+        <p className="text-sm text-muted-foreground">The team guiding our product and customers</p>
+        <div className="mt-6 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+          {[
+            { img: "/leadership/founder.webp", name: "A. Founder", title: "CEO" },
+            { img: "/leadership/cto.webp", name: "B. Engineer", title: "CTO" },
+            { img: "/leadership/finance.webp", name: "C. Finance", title: "Head of Finance & Ops" },
+          ].map((p) => (
+            <div key={p.name}>
+              <Image src={p.img} alt={p.name} width={640} height={640} className="rounded-2xl aspect-square object-cover" />
+              <h3 className="mt-4 font-semibold">{p.name}</h3>
+              <p className="text-muted-foreground">{p.title}</p>
             </div>
-          </SectionCard>
-          <SectionCard id="about-reach-us">
-            <h2 className="text-2xl font-bold">{reachUs.title}</h2>
-            <p className="mt-2 text-[15px] text-slate-700">{reachUs.desc}</p>
-            <ul className="mt-4 space-y-4">
-              {reachUs.contacts.map((c) => (
-                <li key={c.token} className="list-none">
-                  <Button asChild size="sm">
-                    <Link href={`/contact?subject=${c.token}`}>{c.label}</Link>
-                  </Button>
-                  <p className="mt-1 text-sm text-slate-600">{c.desc}</p>
-                </li>
-              ))}
-            </ul>
-            <p className="mt-4 text-xs text-slate-500">{reachUs.note}</p>
-          </SectionCard>
+          ))}
         </div>
-      </Page>
-    </div>
-  );
+      </SectionCard>
+    </Page>
+  )
 }
-

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,15 +1,17 @@
 import "../global.css";
 import MarketingHeader from "@/components/marketing/MarketingHeader";
 import Footer from "@/components/Footer";
-import FloatingTrialCTA from "@/components/marketing/FloatingTrialCTA";
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <MarketingHeader />
-      <main className="pt-14">{children}</main>
+      <main className="min-h-screen">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          {children}
+        </div>
+      </main>
       <Footer />
-      <FloatingTrialCTA />
     </>
   );
 }

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,117 +1,33 @@
-import Link from "next/link";
-import HeroClient from "@/components/marketing/HeroClient";
-import TestimonialsSection from "@/components/marketing/TestimonialsSection";
-import PricingSection from "@/components/marketing/PricingSection";
-import FAQSection from "@/components/marketing/FAQSection";
-import MediaBullets from "@/components/marketing/MediaBullets";
-import FeatureHighlight from "@/components/marketing/FeatureHighlight";
-import { chooseNOnce } from "@/lib/randomize";
-import { heroCopy, HeroKey } from "@/lib/copy/imageCopy";
-import { heroImages } from "@/lib/images";
+import HeroClient from "@/components/marketing/HeroClient"
+import { FeatureCard } from "@/components/marketing/FeatureCard"
+import { heroCopy } from "@/lib/copy/imageCopy"
+import { heroImages } from "@/lib/images"
 
-export default async function HomePage() {
-  const keys = Object.keys(heroImages) as HeroKey[];
-  const [hero1Key, hero2Key, hero3Key] = await chooseNOnce(
-    "hb_home_heroes",
-    keys,
-    3
-  );
-  const hero1 = heroCopy[hero1Key];
-  const hero2 = heroCopy[hero2Key];
-  const hero3 = heroCopy[hero3Key];
-  const hero1Img = heroImages[hero1Key]!;
-  const hero2Img = heroImages[hero2Key]!;
-  const hero3Img = heroImages[hero3Key]!;
-
+export default function MarketingHome() {
+  const hero = heroCopy.accounting
+  const heroImg = heroImages.accounting!
   return (
-    <div>
-      {/* HERO 1 */}
-      <section className="border-b">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <HeroClient
-            itemId={hero1Key}
-            headline={hero1.headline}
-            story={hero1.story}
-            ctas={hero1.ctas}
-            imgSrc={hero1Img}
-            reverse
-          />
-        </div>
+    <div className="space-y-20 py-12 sm:py-16 lg:py-24">
+      <HeroClient
+        itemId="accounting"
+        headline={hero.headline}
+        story={hero.story}
+        ctas={hero.ctas}
+        imgSrc={heroImg}
+      />
+      <section className="space-y-10">
+        <h2 className="text-3xl font-bold">Feature Highlights</h2>
+        <FeatureCard
+          title="Smart Invoices"
+          body="Create VAT-ready invoices with automatic postings."
+          img="/landing/feature-demo.webp"
+        />
+        <FeatureCard
+          title="Dealer COGS"
+          body="Attach purchase, duty, and reconditioning per unit."
+          img="/landing/dealership.webp"
+        />
       </section>
-
-      <FeatureHighlight />
-
-      {/* FEATURES */}
-      <section id="features" className="border-b">
-        <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-          <h2 className="text-2xl font-bold">Built for compliance and speed</h2>
-          <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-3 lg:grid-cols-5">
-            {[
-              { title: "VAT compliance", desc: "Automatic VAT-14 and zero-rated support.", href: "/features#vat" },
-              { title: "PAYE & NIS", desc: "Payroll that stays in step with GRA rules.", href: "/features#payroll" },
-              { title: "Real-time reports", desc: "Know your numbers the instant they change.", href: "/features#reports" },
-              { title: "Bank reconciliation", desc: "Match transactions in minutes, not hours.", href: "/features#banking" },
-              { title: "Multi-currency", desc: "Invoice and track in USD, GYD, and more.", href: "/features#multicurrency" },
-            ].map((f) => (
-              <Link key={f.title} href={f.href} className="rounded-2xl border p-6 hover:bg-muted block">
-                <h3 className="font-semibold">{f.title}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">{f.desc}</p>
-              </Link>
-            ))}
-          </div>
-          </div>
-        </section>
-
-        {/* FEATURE DEMO */}
-        <section className="border-b">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <MediaBullets
-            mediaSrc="/landing/feature-demo-1600x1000.webp"
-            bullets={[
-              "Fast onboarding with guided setup.",
-              "Intuitive dashboard for quick insights.",
-              "Secure cloud backups and access anywhere.",
-            ]}
-            reverse
-          />
-        </div>
-        </section>
-
-        {/* HERO 2 */}
-        <section className="border-b">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <HeroClient
-            itemId={hero2Key}
-            headline={hero2.headline}
-            story={hero2.story}
-            ctas={hero2.ctas}
-            imgSrc={hero2Img}
-          />
-        </div>
-        </section>
-
-      {/* HERO 3 */}
-      <section id="why-local" className="border-t">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <HeroClient
-            itemId={hero3Key}
-            headline={hero3.headline}
-            story={hero3.story}
-            ctas={hero3.ctas}
-            imgSrc={hero3Img}
-          />
-        </div>
-      </section>
-
-      {/* TESTIMONIALS */}
-      <TestimonialsSection />
-
-      {/* PRICING */}
-      <PricingSection />
-
-      {/* FAQ */}
-      <FAQSection />
     </div>
-  );
+  )
 }
-

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,147 +10,152 @@ export default function Footer({ authenticated = false }: FooterProps) {
     ? ({ target: "_blank", rel: "noopener noreferrer" } as const)
     : {};
   return (
-    <footer className="border-t bg-foreground text-background text-sm">
-      <div className="container mx-auto grid gap-8 px-4 py-10 sm:grid-cols-5">
-        <div>
-          <div className="mb-2 font-semibold">Product</div>
-          <ul className="space-y-1 text-background/70">
-            <li>
-              <Link href="/#features" {...linkProps} className="hover:underline">
-                Features
-              </Link>
-            </li>
-            <li>
-              <Link href="/pricing" {...linkProps} className="hover:underline">
-                Pricing
-              </Link>
-            </li>
-            <li>
-              <Link href="/demo" {...linkProps} className="hover:underline">
-                Demo
-              </Link>
-            </li>
-            <li>
-              <Link href="/changelog" {...linkProps} className="hover:underline">
-                Changelog
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="https://status.herobooks.gy"
-                {...linkProps}
-                className="hover:underline"
-              >
-                Status
-              </Link>
-            </li>
-          </ul>
+    <footer className="bg-neutral-900 text-neutral-100">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12 text-sm">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-8">
+          <div>
+            <div className="mb-2 font-semibold">Product</div>
+            <ul className="space-y-1 text-neutral-300">
+              <li>
+                <Link href="/#features" {...linkProps} className="hover:underline">
+                  Features
+                </Link>
+              </li>
+              <li>
+                <Link href="/pricing" {...linkProps} className="hover:underline">
+                  Pricing
+                </Link>
+              </li>
+              <li>
+                <Link href="/demo" {...linkProps} className="hover:underline">
+                  Demo
+                </Link>
+              </li>
+              <li>
+                <Link href="/changelog" {...linkProps} className="hover:underline">
+                  Changelog
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="https://status.herobooks.gy"
+                  {...linkProps}
+                  className="hover:underline"
+                >
+                  Status
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div className="mb-2 font-semibold">Company</div>
+            <ul className="space-y-1 text-neutral-300">
+              <li>
+                <Link href="/about" {...linkProps} className="hover:underline">
+                  About
+                </Link>
+              </li>
+              <li>
+                <Link href="/leadership" {...linkProps} className="hover:underline">
+                  Leadership
+                </Link>
+              </li>
+              <li>
+                <Link href="/careers" {...linkProps} className="hover:underline">
+                  Careers (coming soon)
+                </Link>
+              </li>
+              <li>
+                <Link href="/contact" {...linkProps} className="hover:underline">
+                  Contact
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div className="mb-2 font-semibold">Resources</div>
+            <ul className="space-y-1 text-neutral-300">
+              <li>
+                <Link href="/docs" {...linkProps} className="hover:underline">
+                  Docs/Guides
+                </Link>
+              </li>
+              <li>
+                <Link href="/help" {...linkProps} className="hover:underline">
+                  Help Center
+                </Link>
+              </li>
+              <li>
+                <Link href="/news" {...linkProps} className="hover:underline">
+                  News (WaterNewsGY)
+                </Link>
+              </li>
+              <li>
+                <Link href="/blog" {...linkProps} className="hover:underline">
+                  Blog (Patwua)
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div className="mb-2 font-semibold">Legal</div>
+            <ul className="space-y-1 text-neutral-300">
+              <li>
+                <Link
+                  href="/legal/privacy"
+                  {...linkProps}
+                  className="hover:underline"
+                >
+                  Privacy
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/legal/terms"
+                  {...linkProps}
+                  className="hover:underline"
+                >
+                  Terms
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/legal/data-processing"
+                  {...linkProps}
+                  className="hover:underline"
+                >
+                  Data Processing
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/legal/cookies"
+                  {...linkProps}
+                  className="hover:underline"
+                >
+                  Cookies
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <div className="mb-2 font-semibold">Contact</div>
+            <ul className="space-y-1 text-neutral-300">
+              <li>
+                <a href="mailto:support@herobooks.gy" className="hover:underline">
+                  support@herobooks.gy
+                </a>
+              </li>
+              <li>Georgetown, Guyana</li>
+            </ul>
+          </div>
         </div>
-        <div>
-          <div className="mb-2 font-semibold">Company</div>
-          <ul className="space-y-1 text-background/70">
-            <li>
-              <Link href="/about" {...linkProps} className="hover:underline">
-                About
-              </Link>
-            </li>
-            <li>
-              <Link href="/leadership" {...linkProps} className="hover:underline">
-                Leadership
-              </Link>
-            </li>
-            <li>
-              <Link href="/careers" {...linkProps} className="hover:underline">
-                Careers (coming soon)
-              </Link>
-            </li>
-            <li>
-              <Link href="/contact" {...linkProps} className="hover:underline">
-                Contact
-              </Link>
-            </li>
-          </ul>
+        <div className="mt-10 border-t border-white/10 pt-6 flex items-center justify-between">
+          <p className="text-neutral-300">© {year} heroBooks. Built for businesses in Guyana.</p>
+          <a href="mailto:support@herobooks.gy" className="hover:underline">
+            support@herobooks.gy
+          </a>
         </div>
-        <div>
-          <div className="mb-2 font-semibold">Resources</div>
-          <ul className="space-y-1 text-background/70">
-            <li>
-              <Link href="/docs" {...linkProps} className="hover:underline">
-                Docs/Guides
-              </Link>
-            </li>
-            <li>
-              <Link href="/help" {...linkProps} className="hover:underline">
-                Help Center
-              </Link>
-            </li>
-            <li>
-              <Link href="/news" {...linkProps} className="hover:underline">
-                News (WaterNewsGY)
-              </Link>
-            </li>
-            <li>
-              <Link href="/blog" {...linkProps} className="hover:underline">
-                Blog (Patwua)
-              </Link>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <div className="mb-2 font-semibold">Legal</div>
-          <ul className="space-y-1 text-background/70">
-            <li>
-              <Link
-                href="/legal/privacy"
-                {...linkProps}
-                className="hover:underline"
-              >
-                Privacy
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/legal/terms"
-                {...linkProps}
-                className="hover:underline"
-              >
-                Terms
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/legal/data-processing"
-                {...linkProps}
-                className="hover:underline"
-              >
-                Data Processing
-              </Link>
-            </li>
-            <li>
-              <Link
-                href="/legal/cookies"
-                {...linkProps}
-                className="hover:underline"
-              >
-                Cookies
-              </Link>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <div className="mb-2 font-semibold">Contact</div>
-          <ul className="space-y-1 text-background/70">
-            <li>
-              <a href="mailto:support@herobooks.gy" className="hover:underline">
-                support@herobooks.gy
-              </a>
-            </li>
-            <li>Georgetown, Guyana</li>
-          </ul>
-        </div>
-      </div>
-      <div className="border-t border-background/20 py-4 text-center text-xs text-background/70">
-        © {year} heroBooks. Built for businesses in Guyana.
       </div>
     </footer>
   );

--- a/src/components/marketing/FeatureCard.tsx
+++ b/src/components/marketing/FeatureCard.tsx
@@ -1,27 +1,24 @@
-import { cn } from "@/lib/utils";
+import Image from "next/image"
 
-export default function FeatureCard({
-  title,
-  desc,
-  icon,
-  className,
-}: {
-  title: string;
-  desc: string;
-  icon: React.ReactNode;
-  className?: string;
-}) {
+export function FeatureCard(props: { title: string; body: string; img: string }) {
   return (
-    <div className={cn("rounded-xl border bg-card p-5", className)}>
-      <div className="flex items-start gap-3">
-        <div className="h-9 w-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-          {icon}
-        </div>
-        <div>
-          <div className="font-semibold">{title}</div>
-          <div className="text-sm text-muted-foreground mt-1">{desc}</div>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
+      <div className="order-2 md:order-1">
+        <h3 className="text-2xl font-semibold">{props.title}</h3>
+        <p className="mt-2 text-muted-foreground">{props.body}</p>
+      </div>
+      <div className="order-1 md:order-2">
+        <div className="w-full max-w-sm">
+          <Image
+            src={props.img}
+            alt={props.title}
+            width={800}
+            height={800}
+            className="rounded-2xl aspect-square object-cover"
+            priority={false}
+          />
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/marketing/MarketingHeader.tsx
+++ b/src/components/marketing/MarketingHeader.tsx
@@ -1,65 +1,41 @@
-"use client";
-import Link from "next/link";
-import Image from "next/image";
-import { usePathname } from "next/navigation";
-import { Button } from "@/components/ui/button";
+import Link from "next/link"
+import Image from "next/image"
 
-const nav = [
-  { href: "/features", label: "Features" },
-  { href: "/pricing", label: "Pricing" },
-  { href: "/#why-local", label: "Why Local" },
-  { href: "/contact", label: "Contact" },
-];
+// Simple env-based promo flag; default off
+const PROMO_ENABLED = process.env.MARKETING_PROMO === "true"
 
 export default function MarketingHeader() {
-  const pathname = usePathname();
   return (
-    <header className="sticky top-0 z-40 w-full border-b bg-background/70 backdrop-blur">
-      <div className="container mx-auto flex h-14 items-center">
-        <div className="flex flex-1 items-center">
-          <Link href="/" className="flex items-center gap-2">
-            <Image
-              src="/logos/heroBooks mini Color.png"
-              alt="heroBooks"
-              width={24}
-              height={24}
-            />
-            <span className="font-semibold tracking-tight">heroBooks</span>
-          </Link>
+    <header className="w-full">
+      {PROMO_ENABLED && (
+        <div className="bg-blue-600/95 text-white text-center py-2 text-sm">
+          Early adopters: 2 months 50% off on Business plan. Use code <span className="font-semibold">GYA-LAUNCH</span>.
         </div>
-        <nav className="hidden flex-1 items-center justify-center gap-6 text-sm md:flex">
-          {nav.map((n) => (
-            <Link
-              key={n.href}
-              href={n.href}
-              className={
-                pathname === n.href
-                  ? "text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }
-            >
-              {n.label}
-            </Link>
-          ))}
+      )}
+      <div className="mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8 max-w-7xl">
+        <Link href="/" className="flex items-center gap-2">
+          <Image
+            src="/logos/logo.svg"
+            alt="heroBooks"
+            width={140}
+            height={44}
+            priority
+            className="h-11 w-auto"
+          />
+        </Link>
+        <nav className="hidden md:flex items-center gap-6 text-sm">
+          <Link href="/features">Features</Link>
+          <Link href="/pricing">Pricing</Link>
+          <Link href="/about">Why Local</Link>
+          <Link href="/contact">Contact</Link>
         </nav>
-        <div className="flex flex-1 items-center justify-end gap-2">
-          <Link
-            href="/sign-in"
-            className="rounded-md px-3 py-1.5 text-sm hover:bg-muted"
-          >
-            Sign in
+        <div className="flex items-center gap-3">
+          <Link href="/sign-in" className="text-sm">Sign in</Link>
+          <Link href="/get-started" className="inline-flex items-center rounded-xl bg-blue-600 px-4 py-2 text-white text-sm hover:bg-blue-700">
+            Start free trial
           </Link>
-          <Button asChild>
-            <Link href="/pricing#starter">Start free trial</Link>
-          </Button>
-        </div>
-      </div>
-      <div className="w-full border-t bg-primary/10">
-        <div className="container mx-auto px-4 py-2 text-center text-xs sm:text-sm">
-          🎉 Early adopters: 2 months <b>50% off</b> on Business plan. Use code
-          <b> GYA-LAUNCH</b>.
         </div>
       </div>
     </header>
-  );
+  )
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "DOM",
       "DOM.Iterable"
     ],
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- Overhauled marketing header with optional promo banner and updated navigation
- Restyled footer with dark theme and consolidated layout container
- Simplified marketing pages with new feature cards and refreshed About content

## Testing
- `pnpm lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68befcf929888329863e76c0f252e7c9