### PR TITLE
feat: enhance marketing UI and theme resolution

### DIFF
--- a/src/app/(app)/settings/organization/page.tsx
+++ b/src/app/(app)/settings/organization/page.tsx
@@ -15,7 +15,6 @@ export default function OrganizationSettingsPage() {
       </section>
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">UI & Theme</h2>
-        {/* @ts-expect-error Client Component */}
         <UiSettingsPanel />
       </section>
     </div>

--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image"
 import Page from "@/components/UX/Page"
 import SectionCard from "@/components/UX/SectionCard"
+import ContactClient from "@/app/(marketing)/contact/ContactClient"
 
 export default function AboutPage() {
   return (
@@ -11,10 +12,8 @@ export default function AboutPage() {
           <p className="text-muted-foreground">We’re building modern accounting that understands VAT, PAYE, NIS, and the realities of running a small business in Guyana—with an eye toward the broader Caribbean.</p>
         </div>
       </SectionCard>
-      <SectionCard>
-        <h2 className="text-2xl font-semibold">Leadership</h2>
-        <p className="text-sm text-muted-foreground">The team guiding our product and customers</p>
-        <div className="mt-6 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+      <SectionCard title="Leadership" kicker="The team guiding our product and customers">
+        <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
           {[
             { img: "/leadership/founder.webp", name: "A. Founder", title: "CEO" },
             { img: "/leadership/cto.webp", name: "B. Engineer", title: "CTO" },
@@ -26,6 +25,16 @@ export default function AboutPage() {
               <p className="text-muted-foreground">{p.title}</p>
             </div>
           ))}
+        </div>
+      </SectionCard>
+      <SectionCard title="Careers">
+        <p className="text-muted-foreground">We’ll post opportunities here. In the meantime, send your portfolio to <a className="underline" href="mailto:support@herobooks.gy">support@herobooks.gy</a>.</p>
+      </SectionCard>
+      <SectionCard title="Contact">
+        <div className="max-w-3xl">
+          {/* Existing contact form, embedded at the bottom of About */}
+          {/* @ts-expect-error client */}
+          <ContactClient />
         </div>
       </SectionCard>
     </Page>

--- a/src/app/(marketing)/features/page.tsx
+++ b/src/app/(marketing)/features/page.tsx
@@ -1,17 +1,5 @@
-import { FeatureCard } from "@/components/marketing/FeatureCard"
-import Page from "@/components/UX/Page"
-import SectionCard from "@/components/UX/SectionCard"
-
-export default function FeaturesPage() {
-  return (
-    <Page title="Features" subtitle="A focused toolkit for Guyanese SMEs">
-      <SectionCard>
-        <div className="space-y-10">
-          <FeatureCard title="Smart Invoices" body="VAT-ready, auto-postings." img="/landing/feature-demo.webp" />
-          <FeatureCard title="Dealer COGS" body="Per-unit purchases, duty, repairs." img="/landing/dealership.webp" />
-        </div>
-      </SectionCard>
-    </Page>
-  )
+import { redirect } from "next/navigation"
+export default function FeaturesRedirect() {
+  redirect("/#features")
 }
 

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,33 +1,85 @@
-import HeroClient from "@/components/marketing/HeroClient"
+import Image from "next/image"
 import { FeatureCard } from "@/components/marketing/FeatureCard"
-import { heroCopy } from "@/lib/copy/imageCopy"
-import { heroImages } from "@/lib/images"
+import TestimonialsSection from "@/components/marketing/TestimonialsSection"
+import PricingSection from "@/components/marketing/PricingSection"
+import FAQSection from "@/components/marketing/FAQSection"
+import DemoEnterButton from "@/components/marketing/DemoEnterButton"
 
+// Alternating 1:1 heroes, separated by Section-like content blocks.
 export default function MarketingHome() {
-  const hero = heroCopy.accounting
-  const heroImg = heroImages.accounting!
   return (
-    <div className="space-y-20 py-12 sm:py-16 lg:py-24">
-      <HeroClient
-        itemId="accounting"
-        headline={hero.headline}
-        story={hero.story}
-        ctas={hero.ctas}
-        imgSrc={heroImg}
-      />
-      <section className="space-y-10">
-        <h2 className="text-3xl font-bold">Feature Highlights</h2>
-        <FeatureCard
-          title="Smart Invoices"
-          body="Create VAT-ready invoices with automatic postings."
-          img="/landing/feature-demo.webp"
-        />
-        <FeatureCard
-          title="Dealer COGS"
-          body="Attach purchase, duty, and reconditioning per unit."
-          img="/landing/dealership.webp"
-        />
+    <div className="space-y-28 py-10">
+      {/* Hero #1 (right image, left copy) */}
+      <section className="grid md:grid-cols-2 gap-10 items-center">
+        <div className="order-2 md:order-1 space-y-4">
+          <h1 className="text-4xl font-bold">Local-first accounting for Guyana</h1>
+          <p className="text-muted-foreground">VAT-ready invoices, PAYE/NIS schedules, and reports that match how you actually work.</p>
+          <div className="flex gap-3">
+            <a href="/#pricing" className="inline-flex rounded-xl bg-blue-600 px-4 py-2 text-white text-sm hover:bg-blue-700">Start free trial</a>
+            {/* @ts-expect-error client */}
+            <DemoEnterButton />
+          </div>
+        </div>
+        <div className="order-1 md:order-2">
+          <Image src="/landing/feature-demo.webp" alt="Feature demo" width={800} height={800} className="rounded-2xl aspect-square object-cover" />
+        </div>
+      </section>
+
+      {/* Separator: Feature highlights (anchor) */}
+      <section id="features" className="space-y-10">
+        <h2 className="text-3xl font-bold">Features</h2>
+        <FeatureCard title="Smart Invoices" body="VAT-ready, automatic postings." img="/landing/accounting.webp" />
+        <FeatureCard title="Dealer COGS" body="Per-unit duty & reconditioning built in." img="/landing/dealership.webp" />
+      </section>
+
+      {/* Hero #2 (left image, right copy) */}
+      <section className="grid md:grid-cols-2 gap-10 items-center">
+        <div className="order-1">
+          <Image src="/landing/logistics.webp" alt="Logistics" width={800} height={800} className="rounded-2xl aspect-square object-cover" />
+        </div>
+        <div className="order-2 space-y-4">
+          <h2 className="text-3xl font-bold">Built for SMEs across industries</h2>
+          <p className="text-muted-foreground">From salons to contractors: simple flows, clean exports, solid audit trails.</p>
+        </div>
+      </section>
+
+      {/* Separator: Testimonials */}
+      <section>
+        <TestimonialsSection />
+      </section>
+
+      {/* Hero #3 (right image) */}
+      <section className="grid md:grid-cols-2 gap-10 items-center">
+        <div className="order-2 md:order-1 space-y-4">
+          <h2 className="text-3xl font-bold">Bank import & reconcile</h2>
+          <p className="text-muted-foreground">CSV/OFX import, rules, matches — less manual entry, better books.</p>
+        </div>
+        <div className="order-1 md:order-2">
+          <Image src="/landing/bank.webp" alt="Banking" width={800} height={800} className="rounded-2xl aspect-square object-cover" />
+        </div>
+      </section>
+
+      {/* Anchor: Pricing */}
+      <section id="pricing">
+        <PricingSection />
+      </section>
+
+      {/* Hero #4 (left image) */}
+      <section className="grid md:grid-cols-2 gap-10 items-center">
+        <div className="order-1">
+          <Image src="/landing/salon.webp" alt="Salon" width={800} height={800} className="rounded-2xl aspect-square object-cover" />
+        </div>
+        <div className="order-2 space-y-4">
+          <h2 className="text-3xl font-bold">Close your books with confidence</h2>
+          <p className="text-muted-foreground">P&L, Trial Balance, VAT Summary — and exports your accountant will like.</p>
+        </div>
+      </section>
+
+      {/* Quick FAQ/insights */}
+      <section id="faq">
+        <FAQSection />
       </section>
     </div>
   )
 }
+

--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -1,14 +1,5 @@
-import PricingSection from "@/components/marketing/PricingSection"
-import Page from "@/components/UX/Page"
-import SectionCard from "@/components/UX/SectionCard"
-
-export default function PricingPage() {
-  return (
-    <Page title="Pricing" subtitle="Start simple. Scale when you need.">
-      <SectionCard>
-        <PricingSection />
-      </SectionCard>
-    </Page>
-  )
+import { redirect } from "next/navigation"
+export default function PricingRedirect() {
+  redirect("/#pricing")
 }
 

--- a/src/app/api/settings/ui/route.ts
+++ b/src/app/api/settings/ui/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 import { loadModules } from "@/lib/modules"
+import { prisma } from "@/lib/prisma"
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/authOptions"
 
 type UiSettings = { theme: string; modules: string[] }
 
@@ -10,33 +13,77 @@ function envSettings(): UiSettings {
 }
 
 export async function GET() {
-  // Try cookie override first (per-org/per-device), else env fallback
+  // 1) DB: if orgSettings exists with scope = "site"
+  try {
+    // @ts-ignore dynamic check
+    if ((prisma as any).orgSettings) {
+      // @ts-ignore
+      const row = await (prisma as any).orgSettings.findFirst({
+        where: { scope: "site" },
+        select: { theme: true, modules: true },
+      })
+      if (row?.theme && Array.isArray(row?.modules)) {
+        return NextResponse.json({ theme: row.theme, modules: row.modules, canEditPlatform: await isSystemAdmin() })
+      }
+    }
+  } catch {}
+
+  // 2) Cookie override (browser-scoped)
   try {
     const jar = cookies()
     const raw = jar.get("hb_ui")
     if (raw?.value) {
       const parsed = JSON.parse(raw.value) as UiSettings
       if (parsed?.theme && Array.isArray(parsed.modules)) {
-        return NextResponse.json(parsed)
+        return NextResponse.json({ ...parsed, canEditPlatform: await isSystemAdmin() })
       }
     }
   } catch {}
-  return NextResponse.json(envSettings())
+  // 3) Env fallback
+  return NextResponse.json({ ...envSettings(), canEditPlatform: await isSystemAdmin() })
 }
 
 export async function POST(req: Request) {
+  // platform-level changes are System Admin only
+  if (!(await isSystemAdmin())) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
   const body = await req.json().catch(() => ({} as Partial<UiSettings>))
   const theme = body?.theme || envSettings().theme
   const modules = Array.isArray(body?.modules) ? body.modules : envSettings().modules
 
-  // Persist lightweight override in a cookie (DB-agnostic).
-  const jar = cookies()
-  jar.set("hb_ui", JSON.stringify({ theme, modules }), {
-    httpOnly: false,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 30, // 30 days
-  })
+  // Try DB upsert if model exists; otherwise also set cookie fallback
+  let savedToDb = false
+  try {
+    // @ts-ignore
+    if ((prisma as any).orgSettings) {
+      // A single global "site" scope row
+      // @ts-ignore
+      await (prisma as any).orgSettings.upsert({
+        where: { scope: "site" },
+        create: { scope: "site", theme, modules },
+        update: { theme, modules },
+      })
+      savedToDb = true
+    }
+  } catch {}
+
+  if (!savedToDb) {
+    const jar = cookies()
+    jar.set("hb_ui", JSON.stringify({ theme, modules }), {
+      httpOnly: false,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+    })
+  }
   return NextResponse.json({ theme, modules })
+}
+
+async function isSystemAdmin() {
+  const session = await getServerSession(authOptions as any).catch(() => null)
+  const adminList = (process.env.ADMIN_EMAILS || "").split(",").map((s) => s.trim().toLowerCase()).filter(Boolean)
+  const email = (session?.user as any)?.email?.toLowerCase?.()
+  return !!(email && adminList.includes(email))
 }
 

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -57,6 +57,22 @@
   --color-fg: oklch(0.22 0.03 150);
 }
 
+/* Seasonal: Carnival */
+[data-theme="carnival"] {
+  --color-brand-600: oklch(0.7 0.18 200);   /* vibrant teal/blue */
+  --color-brand-700: oklch(0.62 0.2 200);
+  --color-bg: oklch(1 0 0);
+  --color-fg: oklch(0.2 0 0);
+}
+
+/* Seasonal: Independence */
+[data-theme="independence"] {
+  --color-brand-600: oklch(0.68 0.17 135);  /* vivid green */
+  --color-brand-700: oklch(0.58 0.18 135);
+  --color-bg: oklch(1 0 0);
+  --color-fg: oklch(0.2 0 0);
+}
+
 /* Utility hooks for components that need tokens */
 .hb-card {
   border-radius: var(--radius-card);

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/authOptions";
 
-interface FooterProps {
-  authenticated?: boolean;
-}
-
-export default function Footer({ authenticated = false }: FooterProps) {
-  const linkProps = authenticated
+export default async function Footer() {
+  const session = await getServerSession(authOptions as any).catch(() => null);
+  const linkProps = session
     ? ({ target: "_blank", rel: "noopener noreferrer" } as const)
     : {};
+  const externalTarget = session ? "_blank" : undefined;
   return (
     <footer className="bg-neutral-900 text-neutral-100">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12 text-sm">
@@ -151,7 +151,7 @@ export default function Footer({ authenticated = false }: FooterProps) {
         </div>
         <div className="mt-10 border-t border-white/10 pt-6 flex items-center justify-between">
           <p className="text-neutral-300">© 2025 heroBooks. Built for businesses in Guyana.</p>
-          <a href="mailto:support@herobooks.gy" className="hover:underline">
+          <a href="mailto:support@herobooks.gy" className="hover:underline" target={externalTarget}>
             support@herobooks.gy
           </a>
         </div>

--- a/src/components/marketing/MarketingHeader.tsx
+++ b/src/components/marketing/MarketingHeader.tsx
@@ -1,30 +1,50 @@
 import Link from "next/link"
 import Image from "next/image"
-import { isEnabled } from "@/lib/modules"
+import { resolveUiForRequest, isModuleEnabled } from "@/lib/modules"
+import SearchExpand from "@/components/SearchExpand"
+import ThemeToggle from "@/components/ThemeToggle"
+import NotificationsBell from "@/components/topbar/NotificationsBell"
+import UserMenu from "@/components/topbar/UserMenu"
 
-export default function MarketingHeader() {
+export default async function MarketingHeader() {
+  const ui = await resolveUiForRequest()
   return (
-    <header className="w-full">
-      {isEnabled('promo:banner') && (
+    <header className="w-full sticky top-0 z-40 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      {isModuleEnabled(ui.modules, 'promo:banner') && (
         <div className="bg-blue-600/95 text-white text-center py-2 text-sm">
           Early adopters: 2 months 50% off on Business plan. Use code <span className="font-semibold">GYA-LAUNCH</span>.
         </div>
       )}
       <div className="mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8 max-w-7xl">
-        <Link href="/" className="flex items-center gap-2">
+        {/* Left: logo + primary CTA */}
+        <Link href="/" className="flex items-center gap-3">
           <Image src="/logos/logo.svg" alt="heroBooks" width={160} height={48} priority className="h-12 w-auto" />
         </Link>
-        <nav className="hidden md:flex items-center gap-6 text-sm">
-          <Link href="/features">Features</Link>
-          <Link href="/pricing">Pricing</Link>
-          <Link href="/about">Why Local</Link>
-          <Link href="/contact">Contact</Link>
-        </nav>
-        <div className="flex items-center gap-3">
-          <Link href="/sign-in" className="text-sm">Sign in</Link>
-          <Link href="/get-started" className="inline-flex items-center rounded-xl bg-blue-600 px-4 py-2 text-white text-sm hover:bg-blue-700">
+        <div className="flex items-center gap-6">
+          <Link href="/#pricing" className="hidden sm:inline-flex rounded-xl bg-blue-600 px-4 py-2 text-white text-sm hover:bg-blue-700">
             Start free trial
           </Link>
+        </div>
+
+        {/* Right: nav anchors + tools (search, theme, bell, user) */}
+        <nav className="hidden md:flex items-center gap-6 text-sm">
+          <Link href="/#features">Features</Link>
+          <Link href="/#pricing">Pricing</Link>
+          <Link href="/about">About</Link>
+          <Link href="/help">Help</Link>
+          <Link href="/kb">Docs/Guides</Link>
+        </nav>
+        <div className="flex items-center gap-2">
+          {/* Expandable search */}
+          {/* @ts-expect-error client */}
+          <SearchExpand />
+          {/* Dark mode toggle keeps 'class' strategy for dark: variants */}
+          <ThemeToggle />
+          {/* Platform notifications only (visitor-side) */}
+          {/* @ts-expect-error client */}
+          <NotificationsBell />
+          {/* Auth dropdown: Sign in / Sign up links (plan selection) */}
+          <UserMenu />
         </div>
       </div>
     </header>

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -2,12 +2,13 @@ export type ModuleKey =
   | 'ui:nav:marketing'
   | 'ui:nav:app'
   | 'ui:footer:default'
+  | 'ui:footer:alt'
   | 'ui:hero:default'
   | 'ux:page'
   | 'ux:section-card'
   | 'promo:banner';
 
-export type ThemeKey = 'default' | 'christmas';
+export type ThemeKey = 'default' | 'christmas' | 'carnival' | 'independence';
 
 const DEFAULT_MODULES: Readonly<ModuleKey[]> = [
   'ui:nav:marketing',
@@ -24,6 +25,7 @@ function parseList(val?: string): string[] {
     .filter(Boolean);
 }
 
+/** Build-time defaults (env). */
 export function loadModules() {
   const envEnabled = parseList(process.env.MODULES_ENABLED) as ModuleKey[];
   const enabled = new Set<ModuleKey>([...DEFAULT_MODULES, ...envEnabled]);
@@ -37,4 +39,47 @@ export function isEnabled(key: ModuleKey) {
 
 export function activeTheme(): ThemeKey {
   return loadModules().theme;
+}
+
+/** Request-aware resolution (SSR): DB → cookie → env */
+import { cookies } from "next/headers";
+import { prisma } from "@/lib/prisma";
+
+export async function resolveUiForRequest() {
+  // 1) DB: try orgSettings if it exists and flagged as site/global
+  try {
+    // We don't know your exact schema; access through 'any' and catch if the model/fields don't exist.
+    // @ts-ignore - runtime guard
+    if ((prisma as any).orgSettings) {
+      // Try a single global row — adapt later to a dedicated SiteSettings if desired.
+      // @ts-ignore
+      const row = await (prisma as any).orgSettings.findFirst({
+        where: { scope: "site" },
+        select: { theme: true, modules: true },
+      });
+      if (row && Array.isArray(row.modules) && typeof row.theme === "string") {
+        return { theme: row.theme as ThemeKey, modules: new Set<ModuleKey>(row.modules) };
+      }
+    }
+  } catch {}
+
+  // 2) Cookie override (per-browser preview)
+  try {
+    const jar = cookies();
+    const raw = jar.get("hb_ui");
+    if (raw?.value) {
+      const parsed = JSON.parse(raw.value) as { theme?: string; modules?: string[] };
+      if (parsed?.theme && Array.isArray(parsed.modules)) {
+        return { theme: parsed.theme as ThemeKey, modules: new Set<ModuleKey>(parsed.modules as ModuleKey[]) };
+      }
+    }
+  } catch {}
+
+  // 3) Env defaults
+  const env = loadModules();
+  return { theme: env.theme, modules: env.enabled };
+}
+
+export function isModuleEnabled(mods: Set<ModuleKey>, key: ModuleKey) {
+  return mods.has(key);
 }


### PR DESCRIPTION
## Summary
- add request-aware module/theme resolution with DB and cookie fallbacks
- expand marketing pages into a single anchored layout with sticky header
- support seasonal themes and admin-restricted UI settings persistence

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf9bdd39f88329b62a45e4b89d3c50