### PR TITLE
feat: show session expired toast

### DIFF
--- a/src/components/topbar/UserMenu.tsx
+++ b/src/components/topbar/UserMenu.tsx
@@ -7,12 +7,14 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/compon
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { User } from "lucide-react"
+import Toast from "@/components/Toast"
 
 export default function UserMenu() {
   const { data } = useSession()
   const params = useSearchParams()
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
+  const [toast, setToast] = useState(false)
   const emailRef = useRef<HTMLInputElement>(null)
   const passRef = useRef<HTMLInputElement>(null)
   const authParam = params.get("auth")
@@ -30,7 +32,10 @@ export default function UserMenu() {
   }, [params, pathname])
 
   useEffect(() => {
-    if (authParam === "1") setOpen(true)
+    if (authParam === "1") {
+      setOpen(true)
+      setToast(true)
+    }
   }, [authParam])
 
   if (data?.user) {
@@ -54,39 +59,48 @@ export default function UserMenu() {
   }
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <button className="inline-flex items-center gap-2 text-sm">
-          <User className="h-4 w-4" />
-          Sign in
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-80 p-4 space-y-3">
-        <form onSubmit={handleCredentials} className="space-y-3">
-          <div className="space-y-1">
-            <label className="text-xs font-medium">Email</label>
-            <Input ref={emailRef} type="email" placeholder="you@example.com" required />
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <button className="inline-flex items-center gap-2 text-sm">
+            <User className="h-4 w-4" />
+            Sign in
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-80 p-4 space-y-3">
+          <form onSubmit={handleCredentials} className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-xs font-medium">Email</label>
+              <Input ref={emailRef} type="email" placeholder="you@example.com" required />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium">Password</label>
+              <Input ref={passRef} type="password" placeholder="••••••••" required />
+            </div>
+            <Button type="submit" className="w-full">Sign in</Button>
+          </form>
+          <div className="flex items-center justify-between text-xs">
+            <Link href="/forgot-password" className="underline">Forgot password</Link>
+            <Link href="/#pricing" className="underline">Create account</Link>
           </div>
-          <div className="space-y-1">
-            <label className="text-xs font-medium">Password</label>
-            <Input ref={passRef} type="password" placeholder="••••••••" required />
+          <div className="pt-2">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => signIn("google", { callbackUrl })}
+            >
+              Sign in with Google
+            </Button>
           </div>
-          <Button type="submit" className="w-full">Sign in</Button>
-        </form>
-        <div className="flex items-center justify-between text-xs">
-          <Link href="/forgot-password" className="underline">Forgot password</Link>
-          <Link href="/#pricing" className="underline">Create account</Link>
-        </div>
-        <div className="pt-2">
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={() => signIn("google", { callbackUrl })}
-          >
-            Sign in with Google
-          </Button>
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {toast && (
+        <Toast
+          type="error"
+          message="Session expired — please sign in"
+          onDone={() => setToast(false)}
+        />
+      )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- display a helpful toast when the sign-in dropdown auto-opens on session expiry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfa2c5937883298ef4fb07fd0ff575