### PR TITLE
fix: wrap UserMenu in suspense for KB pages

### DIFF
--- a/src/app/kb/KbShell.tsx
+++ b/src/app/kb/KbShell.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import ThemeToggle from "@/components/topbar/ThemeToggle";
 import NotificationsBell from "@/components/topbar/NotificationsBell";
 import UserMenu from "@/components/topbar/UserMenu";
-import React, { useState } from "react";
+import React, { Suspense, useState } from "react";
 
 type Article = {
   slug: string;
@@ -62,7 +62,9 @@ export default function KbShell({
         <div className="flex items-center gap-2">
           <ThemeToggle />
           <NotificationsBell />
-          <UserMenu />
+          <Suspense fallback={null}>
+            <UserMenu />
+          </Suspense>
         </div>
       </header>
       <div className="flex flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary
- wrap UserMenu in a Suspense boundary within the KB shell to satisfy Next.js `useSearchParams` requirements

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa477dcc8832988a50d9210b4c07e