### PR TITLE
Show toast on session expiry and wrap UserMenu in Suspense

### DIFF
--- a/src/app/kb/KbShell.tsx
+++ b/src/app/kb/KbShell.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import ThemeToggle from "@/components/topbar/ThemeToggle";
 import NotificationsBell from "@/components/topbar/NotificationsBell";
 import UserMenu from "@/components/topbar/UserMenu";
-import React, { useState } from "react";
+import React, { useState, Suspense } from "react";
 
 type Article = {
   slug: string;
@@ -62,7 +62,9 @@ export default function KbShell({
         <div className="flex items-center gap-2">
           <ThemeToggle />
           <NotificationsBell />
-          <UserMenu />
+          <Suspense fallback={null}>
+            <UserMenu />
+          </Suspense>
         </div>
       </header>
       <div className="flex flex-1 overflow-hidden">

--- a/src/components/auth/AuthAutoOpen.tsx
+++ b/src/components/auth/AuthAutoOpen.tsx
@@ -1,11 +1,14 @@
 "use client"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
+import Toast from "@/components/Toast"
 
 /**
  * Installs a global fetch wrapper. Any 401 response from same-origin requests
  * triggers the marketing sign-in dropdown to open immediately.
  */
 export default function AuthAutoOpen() {
+  const [showToast, setShowToast] = useState(false)
+
   useEffect(() => {
     // Only install once
     if ((window as any).__hbFetchPatched) return
@@ -23,10 +26,18 @@ export default function AuthAutoOpen() {
           const u = new URL(window.location.href)
           u.searchParams.set("auth", "1")
           window.history.replaceState(null, "", u.toString())
+          setShowToast(true)
         }
       } catch {}
       return res
     }
   }, [])
-  return null
+
+  return showToast ? (
+    <Toast
+      type="error"
+      message="Session expired — please sign in"
+      onDone={() => setShowToast(false)}
+    />
+  ) : null
 }

--- a/src/components/marketing/MarketingHeader.tsx
+++ b/src/components/marketing/MarketingHeader.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import Image from "next/image"
+import { Suspense } from "react"
 import { resolveUiForRequest, isModuleEnabled } from "@/lib/modules"
 import SearchExpand from "@/components/SearchExpand"
 import ThemeToggle from "@/components/ThemeToggle"
@@ -42,7 +43,9 @@ export default async function MarketingHeader() {
           {/* Platform notifications only (visitor-side) */}
           <NotificationsBell />
           {/* Auth dropdown: Sign in / Sign up links (plan selection) */}
-          <UserMenu />
+          <Suspense fallback={null}>
+            <UserMenu />
+          </Suspense>
         </div>
       </div>
     </header>

--- a/src/components/topbar/Topbar.tsx
+++ b/src/components/topbar/Topbar.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import { Suspense } from "react";
 import { isDemoModeFromCookies } from "@/lib/demo";
 import SearchBar from "./SearchBar";
 import ThemeToggle from "./ThemeToggle";
@@ -35,7 +36,9 @@ export default async function Topbar() {
         <nav className="flex items-center gap-3 ml-auto">
           <ThemeToggle />
           <NotificationsBell />
-          <UserMenu />
+          <Suspense fallback={null}>
+            <UserMenu />
+          </Suspense>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- show a toast when 401 responses trigger the auth dropdown, clarifying session expiry
- wrap UserMenu with Suspense in headers to satisfy Next.js `useSearchParams` requirement
- ensure KB shell also wraps the auth menu in Suspense

## Testing
- `pnpm build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bfa562849083299ea0158f9acb1eb3