### PR TITLE
fix: read secure session cookies in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,11 @@ export async function middleware(req: NextRequest) {
   if (!isProtected) return NextResponse.next()
 
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET
-  const token = await getToken({ req, secret })
+  const token = await getToken({
+    req,
+    secret,
+    secureCookie: req.nextUrl.protocol === "https:",
+  })
 
   if (token) return NextResponse.next()
 


### PR DESCRIPTION
## Summary
- include `secureCookie` option when decoding Auth.js session token

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68bfa84f68248329b24ddd2eca7f870f