### PR TITLE
fix: sanitize KB markdown and revert ESM config

### DIFF
--- a/kb/articles/accounting-equation-fundamentals.md
+++ b/kb/articles/accounting-equation-fundamentals.md
@@ -1,80 +1,93 @@
 ---
-id: getting-started-7
+id: accounting-equation-fundamentals-2025
 slug: accounting-equation-fundamentals
-title: Accounting equation fundamentals
-summary: This article covers accounting equation fundamentals for Guyanese businesses,
-  explaining key principles and how to apply them in practice.
+title: Accounting equation fundamentals (Assets = Liabilities + Equity)
+summary: The bedrock of double-entry accounting, explained with a Guyana-ready example in GYD and quick checks you can apply before you close.
 level: Beginner
-audience:
-- Owner
-- Accountant
-- Clerk
+audience: [Student, Owner, Clerk]
 format: Guide
-category_id: getting-started
-tags:
-- accounting
-- getting
-- started
-- equation
-- fundamentals
-jurisdiction:
-- Guyana
-last_reviewed: '2025-09-07'
+category_id: start-here
+tags: [accounting equation, double-entry, PoA, balance sheet]
+jurisdiction: [Guyana, Caribbean]
+last_reviewed: "2025-09-09"
+facts_verified_on: "2025-09-09"
 sources:
-- title: "Notice to Employers, Employees & Self-Employed Persons \u2013 Revised Personal\
-    \ Allowance 2025"
-  url: https://www.gra.gov.gy/notice-to-employers-employees-self-employed-persons-revised-personal-allowance-and-deductions-for-income-tax-2025-copy/
-  publisher: Guyana Revenue Authority
-  date_accessed: '2025-09-07'
+  - title: "CSEC Principles of Accounts — Syllabus"
+    url: "https://www.cxc.org/SiteAssets/syllabusses/CSEC/CSEC%20Principles%20of%20Accounts.pdf"
+    publisher: Caribbean Examinations Council (CXC)
+    date_accessed: "2025-09-09"
+  - title: "IFRS for SMEs (3rd ed., 2025) — Section 2 Concepts & Pervasive Principles"
+    url: "https://www.ifrs.org/content/dam/ifrs/publications/ifrs-for-smes/english/2025/ifrs-for-smes.pdf?bypass=on"
+    publisher: IFRS Foundation
+    date_accessed: "2025-09-09"
 kb_snippets:
-- question: What is accounting equation fundamentals?
-  answer: 'Accounting equation fundamentals refers to the accounting concept or practice
-    described in the article. It outlines the fundamentals and explains why it matters
-    in Guyana or the Caribbean. Next actions: Read this article and follow the steps
-    in heroBooks.'
-  type: definition
-- question: How do I perform accounting equation fundamentals in heroBooks?
-  answer: 'This article provides a step-by-step guide on accounting equation fundamentals.
-    It includes practical examples using Guyanese currency (GYD) and highlights local
-    compliance points. Next actions: Follow the step-by-step section and use the linked
-    heroBooks feature.'
-  type: howto
-- question: Why is accounting equation fundamentals important?
-  answer: 'Understanding accounting equation fundamentals helps ensure accurate accounting
-    records and compliance with GRA and NIS requirements. It improves decision-making
-    and financial transparency for Guyanese businesses. Next actions: Implement the
-    best practices outlined in the article.'
-  type: faq
-assistant_keys:
-- intent: ASK
-  key: accounting_equation_fundamentals
-  synonyms:
-  - accounting
-  - equation
-  - fundamentals
-  link: /help
+  - question: What is the accounting equation?
+    answer: The accounting equation states that Assets = Liabilities + Equity. It must hold after every transaction; it’s the basis of double-entry and the balance sheet.
+    type: definition
+  - question: How do debits and credits relate to the equation?
+    answer: Debits increase assets and expenses; credits increase equity, income, and liabilities. Every transaction posts equal debits and credits to keep A = L + E.
+    type: howto
+  - question: Why does the equation matter for PoA and heroBooks?
+    answer: It underpins the balance sheet tested in CXC PoA and ensures your ledger stays in balance in heroBooks after every journal or document you post.
+    type: faq
 ---
 
-### Introduction
-Accounting equation fundamentals is an important topic for businesses in Guyana and the Caribbean. This section explains what it is and why it matters.
+## What the equation says (and why it never “breaks”)
+The **accounting equation** is:
 
-### Key Concepts
-Discuss the foundational principles, linking back to Principles of Accounts (PoA) where applicable.
+> **Assets = Liabilities + Equity**
 
-### Guyana specifics
-Provide current rates, forms, deadlines, and rules relevant to Guyana. Remember to indicate that figures are subject to change and cite official sources.
+It must hold **after every transaction**—not just at month-end. This is the core of double-entry bookkeeping taught in **CSEC Principles of Accounts** and used in practice to present a statement of financial position (balance sheet). :contentReference[oaicite:1]{index=1}
 
-### Step-by-step guidance
-Outline practical steps and reference heroBooks features or pages using appropriate links.
+### The building blocks (IFRS for SMEs terms)
+- **Assets**: present economic resources controlled by the entity as a result of past events (e.g., cash, inventory, receivables).  
+- **Liabilities**: present obligations to transfer an economic resource as a result of past events (e.g., loans, payables).  
+- **Equity**: residual interest in the assets after deducting liabilities (owner’s capital, retained profit).  
+These definitions come from **IFRS for SMEs (2025), Section 2**. :contentReference[oaicite:2]{index=2}
 
-### Worked example
-Include a practical example using Guyanese dollars (GYD) to demonstrate the concept.
+## Debits, credits, and the equation
+- **Debits (Dr)** increase **Assets** (and Expenses); **Credits (Cr)** increase **Liabilities**, **Equity** (and Income).  
+- Every transaction records **equal** debits and credits. That equality is what keeps **A = L + E** true at all times.
 
-### Common pitfalls & checks
-Highlight typical mistakes and provide tips on how to avoid them.
+## Worked example (GYD)
+Keisha starts a small service business in Georgetown:
 
-### Glossary
-Define important terms related to the topic.
+1. Owner invests **G$600,000** cash.  
+   - Dr Cash 600,000 | Cr Owner’s Capital 600,000  
+   - Equation: **Assets 600,000 = Liabilities 0 + Equity 600,000**
 
-### References
-List the sources cited in the article with retrieval dates.
+2. Business takes a **bank loan G$300,000**.  
+   - Dr Cash 300,000 | Cr Bank Loan (Liability) 300,000  
+   - Equation: **Assets 900,000 = Liabilities 300,000 + Equity 600,000**
+
+3. Buys **inventory G$180,000** on credit.  
+   - Dr Inventory 180,000 | Cr Accounts Payable 180,000  
+   - Equation: **Assets 1,080,000 = Liabilities 480,000 + Equity 600,000**
+
+4. Sells goods for **G$240,000** on credit; cost **G$120,000**.  
+   - Dr Accounts Receivable 240,000 | Cr Sales (Income→Equity) 240,000  
+   - Dr Cost of Sales 120,000 | Cr Inventory 120,000  
+   - Net effect: Assets +120,000 (A/R ↑ 240,000; Inventory ↓ 120,000); Equity +120,000 (Profit).  
+   - Equation: **Assets 1,200,000 = Liabilities 480,000 + Equity 720,000**
+
+5. Pays supplier **G$100,000** toward the payable.  
+   - Dr Accounts Payable 100,000 | Cr Cash 100,000  
+   - Equation: **Assets 1,100,000 = Liabilities 380,000 + Equity 720,000**
+
+Final balances still satisfy **A = L + E**. If your books don’t, a posting is missing or misclassified.
+
+## Common pitfalls & quick checks
+- **Single-sided posting**: every journal must have **Dr = Cr** totals.  
+- **Misclassifying owner drawings** as expenses (drawings reduce **Equity**, not an expense).  
+- **Confusing revenue with cash**: credit sales increase **Assets (A/R)** and **Equity (income)** even before cash arrives.  
+- **Inventory**: selling inventory reduces **Assets** (inventory) and increases **Expenses** (cost of sales), affecting **Equity**.
+
+### Two 30-second tests
+1) Trial balance **debits = credits**? If not, the equation will fail.  
+2) Rebuild the balance sheet: does **Assets − Liabilities = Equity**? If not, trace back the last batch of entries.
+
+## In heroBooks
+- All sales, purchases, receipts, and journal entries are **double-entry**.  
+- The **dashboard and balance sheet** reflect the equation automatically; if a posting is incomplete, you’ll see it immediately in the trial balance.
+
+

--- a/package.json
+++ b/package.json
@@ -68,6 +68,5 @@
       "prisma",
       "sharp"
     ]
-  },
-  "type": "module"
+  }
 }

--- a/scripts/build-kb-index.js
+++ b/scripts/build-kb-index.js
@@ -3,10 +3,10 @@
      pnpm run kb:build           # builds indexes
      pnpm run kb:check           # same, but CI guard
 */
-import fs from "node:fs";
-import path from "node:path";
-import matter from "gray-matter";
-import { marked } from "marked";
+const fs = require("node:fs");
+const path = require("node:path");
+const matter = require("gray-matter");
+const { marked } = require("marked");
 
 const ROOT = process.cwd();
 const ARTICLES_DIR = path.join(ROOT, "kb", "articles");

--- a/src/app/kb/[slug]/page.tsx
+++ b/src/app/kb/[slug]/page.tsx
@@ -9,7 +9,7 @@ export default function KbArticle({ params }: { params: { slug: string } }) {
   const file = findArticle(params.slug);
   const raw = fs.readFileSync(file, "utf8");
   const { data, content } = matter(raw);
-  const html = marked.parse(content);
+  const html = marked.parse(escapeHtml(content));
 
   return (
     <Page title={data.title} subtitle={data.summary}>
@@ -58,6 +58,15 @@ export default function KbArticle({ params }: { params: { slug: string } }) {
       </div>
     </Page>
   );
+}
+
+function escapeHtml(html: string) {
+  return html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
 }
 
 function findArticle(slug: string) {


### PR DESCRIPTION
## Summary
- replace accounting equation article with finished, citation-backed content
- remove `type: "module"` and convert KB build script to CommonJS
- escape HTML when rendering KB articles to prevent injection

## Testing
- `pnpm run kb:build` *(fails: ❌ Placeholder text found in accounting-for-maintenance-and-repairs.md)*

------
https://chatgpt.com/codex/tasks/task_e_68c057659ab08329849c29bb52a15798