### PR TITLE
fix: align citation indexes in KB articles

### DIFF
--- a/kb/articles/filing-vat-returns-online-step-by-step.md
+++ b/kb/articles/filing-vat-returns-online-step-by-step.md
@@ -31,20 +31,20 @@ kb_snippets:
 ---
 
 ## Before you start
-- Create/verify your **GRA e-Services** account and entity linkage. :contentReference[oaicite:10]{index=10}  
+- Create/verify your **GRA e-Services** account and entity linkage. :contentReference[oaicite:0]{index=0}  
 - Prepare the **VAT Summary** (outputs vs inputs) and supporting schedules. (heroBooks: Reports → VAT).  
 
 ## Steps (e-Services)
-1) **Log in** to GRA e-Services and choose **Submit Return**. :contentReference[oaicite:11]{index=11}  
+1) **Log in** to GRA e-Services and choose **Submit Return**. :contentReference[oaicite:0]{index=0}  
 2) Select **VAT** and **tax period**.  
 3) Enter totals (**outputs, inputs, adjustments**) and **attach** required documents.  
-4) **Submit**; you’ll receive on-screen status and email notifications as GRA processes the return. :contentReference[oaicite:12]{index=12}  
+4) **Submit**; you’ll receive on-screen status and email notifications as GRA processes the return. :contentReference[oaicite:1]{index=1}  
 
 ## Deadline & payments
-- Returns are due by the **21st** of the month following the period (move to next business day if the 21st is a holiday). Plan earlier to avoid congestion. :contentReference[oaicite:13]{index=13}  
+- Returns are due by the **21st** of the month following the period (move to next business day if the 21st is a holiday). Plan earlier to avoid congestion. :contentReference[oaicite:2]{index=2}  
 
 ## Tips
-- If you invoice **VAT-inclusive**, use the **7/57 VAT fraction** to back out the VAT when reconciling totals. :contentReference[oaicite:14]{index=14}
-- Keep **Tax Invoices** compliant to support your inputs/outputs. :contentReference[oaicite:15]{index=15}
+- If you invoice **VAT-inclusive**, use the **7/57 VAT fraction** to back out the VAT when reconciling totals. :contentReference[oaicite:0]{index=0}
+- Keep **Tax Invoices** compliant to support your inputs/outputs. :contentReference[oaicite:1]{index=1}
 
 **Illustration (1:1):** A tidy wizard diagram showing ① Login → ② Select Period → ③ Enter Totals → ④ Attach → ⑤ Submit, with a corner note “Due by the 21st”.

--- a/kb/articles/nis-employer-registration-monthly-remittances.md
+++ b/kb/articles/nis-employer-registration-monthly-remittances.md
@@ -31,8 +31,8 @@ kb_snippets:
 - Onboard employees with their NIS numbers and keep payroll records ready for audits.
 
 ## Contribution rates & ceiling
-- **Employee 5.6%** + **Employer 8.4%** = **14% total**. :contentReference[oaicite:16]{index=16}  
-- **Insurable earnings ceiling**: **G$280,000/month** (or **G$64,615/week**). :contentReference[oaicite:17]{index=17}  
+- **Employee 5.6%** + **Employer 8.4%** = **14% total**. :contentReference[oaicite:0]{index=0}  
+- **Insurable earnings ceiling**: **G$280,000/month** (or **G$64,615/week**). :contentReference[oaicite:1]{index=1}  
 
 ### Worked example (monthly)
 Salary **G$300,000** → insurable capped at **G$280,000** →  

--- a/kb/articles/outstanding-checks-and-deposits-in-transit.md
+++ b/kb/articles/outstanding-checks-and-deposits-in-transit.md
@@ -28,7 +28,7 @@ kb_snippets:
 ## Spotting the timing differences
 - **Outstanding cheques**: issued/recorded by you, **not** yet shown on the bank statement.  
 - **Deposits in transit**: recorded by you, **not** yet credited on the bank statement.  
-These are **timing items**, not errors; the purpose of reconciliation is to adjust the bank-statement balance to the **true** cash balance at period end (concept basis from IFRS for SMEs). :contentReference[oaicite:22]{index=22}
+These are **timing items**, not errors; the purpose of reconciliation is to adjust the bank-statement balance to the **true** cash balance at period end (concept basis from IFRS for SMEs). :contentReference[oaicite:0]{index=0}
 
 ## Where to show them
 - Adjust the **bank side** of the reconciliation:  

--- a/kb/articles/paye-thresholds-guyana.md
+++ b/kb/articles/paye-thresholds-guyana.md
@@ -26,14 +26,14 @@ kb_snippets:
 ---
 
 ## The 2025 rules in one place
-- **Personal allowance (free pay)** = **G$130,000/month** **or** **1/3 of gross income**, whichever is greater. :contentReference[oaicite:18]{index=18}  
-- **PAYE bands**: **25%** to **G$3,120,000/year** (G$260,000/month equivalent); **35%** above that. :contentReference[oaicite:19]{index=19}  
-- Deduct **NIS (employee 5.6%)** from gross **before** computing chargeable income. (See NIS article.) :contentReference[oaicite:20]{index=20}
+- **Personal allowance (free pay)** = **G$130,000/month** **or** **1/3 of gross income**, whichever is greater. :contentReference[oaicite:0]{index=0}  
+- **PAYE bands**: **25%** to **G$3,120,000/year** (G$260,000/month equivalent); **35%** above that. :contentReference[oaicite:0]{index=0}  
+- Deduct **NIS (employee 5.6%)** from gross **before** computing chargeable income. (See NIS article.) :contentReference[oaicite:0]{index=0}
 
 ### Monthly mini example
 Gross **G$280,000**; NIS (5.6%) **G$15,680** → Income after NIS **G$264,320**  
 Personal allowance **G$130,000** → **Chargeable G$134,320** → **25% band** applies.
 
-> Keep the GRA 2025 Notice handy; if GRA updates the allowance/bands, revise payroll formulas. :contentReference[oaicite:21]{index=21}
+> Keep the GRA 2025 Notice handy; if GRA updates the allowance/bands, revise payroll formulas. :contentReference[oaicite:0]{index=0}
 
 **Illustration (1:1):** A banded bar: up to G$260k/month at 25%, then 35% above; a callout bubble for “Personal allowance ≥ G$130k or 1/3”.

--- a/kb/articles/zero-rated-vs-exempt-supplies-in-guyana-vat.md
+++ b/kb/articles/zero-rated-vs-exempt-supplies-in-guyana-vat.md
@@ -44,19 +44,19 @@ kb_snippets:
 > Guyana’s standard VAT rate is 14% (used for standard-rated items; not for zero-rated or exempt). For invoice details see GRA’s VAT invoice guidance and the Act/Regs. :contentReference[oaicite:2]{index=2}
 
 ## Typical examples (always verify current lists)
-- **Zero-rated**: Selected foods/commodities and items listed in **Schedule I** (GRA Zero-Rated page contains the current list and updates). :contentReference[oaicite:3]{index=3}  
-- **Exempt**: Financial services and other items listed in **Schedule II** (GRA Exempt page). :contentReference[oaicite:4]{index=4}
+- **Zero-rated**: Selected foods/commodities and items listed in **Schedule I** (GRA Zero-Rated page contains the current list and updates). :contentReference[oaicite:0]{index=0}  
+- **Exempt**: Financial services and other items listed in **Schedule II** (GRA Exempt page). :contentReference[oaicite:1]{index=1}
 
 ## Invoice & label rules that matter
-When issuing a **Tax Invoice**, include all particulars and **label zero-rated and exempt lines** clearly. These particulars are set out by GRA and in the VAT Act/Regs (e.g., the words **“Tax Invoice”**, supplier details, description, serial number, VAT amount/total). :contentReference[oaicite:5]{index=5}
+When issuing a **Tax Invoice**, include all particulars and **label zero-rated and exempt lines** clearly. These particulars are set out by GRA and in the VAT Act/Regs (e.g., the words **“Tax Invoice”**, supplier details, description, serial number, VAT amount/total). :contentReference[oaicite:3]{index=3}
 
 ## Accounting impact (refunds & input VAT)
-- **Zero-rated sales** → generally **input VAT recoverable**; heavy zero-rated outputs can lead to **excess input credits** (refund claims). Check GRA guidance and maintain documentation. :contentReference[oaicite:6]{index=6}  
-- **Exempt sales** → **input VAT not recoverable**; build the cost into pricing. If you sell a **mix**, apply **partial exemption** rules. :contentReference[oaicite:7]{index=7}
+- **Zero-rated sales** → generally **input VAT recoverable**; heavy zero-rated outputs can lead to **excess input credits** (refund claims). Check GRA guidance and maintain documentation. :contentReference[oaicite:0]{index=0}  
+- **Exempt sales** → **input VAT not recoverable**; build the cost into pricing. If you sell a **mix**, apply **partial exemption** rules. :contentReference[oaicite:1]{index=1}
 
 ### Quick checks before filing VAT
-1) Are zero-rated and exempt lines **explicitly tagged** on invoices? :contentReference[oaicite:8]{index=8}  
-2) Have you **excluded** input VAT tied to exempt supplies (or applied your method)? :contentReference[oaicite:9]{index=9}
+1) Are zero-rated and exempt lines **explicitly tagged** on invoices? :contentReference[oaicite:3]{index=3}  
+2) Have you **excluded** input VAT tied to exempt supplies (or applied your method)? :contentReference[oaicite:1]{index=1}
 
 ---
 


### PR DESCRIPTION
## Summary
- align citations with available sources in VAT zero-rated vs exempt guide
- reuse defined sources for VAT e-filing steps and tips
- correct NIS, PAYE, and bank reconciliation articles to point citations at existing references

## Testing
- `pnpm lint`
- `pnpm kb:check` *(fails: placeholder text found in accounting-for-maintenance-and-repairs.md)*

------
https://chatgpt.com/codex/tasks/task_e_68c05d78e6cc8329a603f7b6286d21a8