### PR TITLE
docs: add maintenance vs capital improvements guide

### DIFF
--- a/kb/articles/accounting-for-maintenance-and-repairs.md
+++ b/kb/articles/accounting-for-maintenance-and-repairs.md
@@ -16,21 +16,21 @@ sources:
     url: "https://www.ifrs.org/content/dam/ifrs/publications/ifrs-for-smes/english/2025/ifrs-for-smes.pdf?bypass=on"
     publisher: IFRS Foundation
     date_accessed: "2025-09-09"
-  - title: "IAS 16 — Property, Plant and Equipment (full standard PDF)"
-    url: "https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards/english/2022/issued/part-a/ias-16-property-plant-and-equipment.pdf?bypass=on"
+  - title: "IAS 16 — Property, Plant and Equipment (overview)"
+    url: "https://www.ifrs.org/issued-standards/list-of-standards/ias-16-property-plant-and-equipment/"
     publisher: IFRS Foundation
     date_accessed: "2025-09-09"
-  - title: "IFRS for SMEs — Implementation Module 17 (PPE)"
-    url: "https://www.ifrs.org/content/dam/ifrs/supporting-implementation/smes/module-17.pdf"
+  - title: "IAS 16 — Property, Plant and Equipment (full standard PDF)"
+    url: "https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards/english/2022/issued/part-a/ias-16-property-plant-and-equipment.pdf?bypass=on"
     publisher: IFRS Foundation
     date_accessed: "2025-09-09"
   - title: "GRA Policy 6 — VAT and Capital Equipment & Machinery"
     url: "https://www.gra.gov.gy/policy-6-vat-and-capital-equipment/"
     publisher: Guyana Revenue Authority
     date_accessed: "2025-09-09"
-  - title: "Guyana VAT Act/Regulations (input tax credit principles)"
-    url: "https://parliament.gov.gy/documents/bills/5342-new_profile_3.pdf"
-    publisher: Parliament of Guyana (Legal Supplement)
+  - title: "Guyana VAT Act & Regulations (revised Feb 8, 2024) — input tax/partial exemption"
+    url: "https://www.gra.gov.gy/wp-content/uploads/2024/03/VAT-Act-Regul.-Trans.-Reg.-revised-Feb-8-2024.pdf"
+    publisher: Guyana Revenue Authority
     date_accessed: "2025-09-09"
 
 kb_snippets:
@@ -46,59 +46,57 @@ kb_snippets:
 ---
 
 ## The rule in one minute
-- **Expense** **day-to-day servicing** (e.g., oil, filters, minor fixes) — these keep the asset running but **do not** increase capacity or extend useful life. :contentReference[oaicite:0]{index=0}
-- **Capitalise** **significant replacements or upgrades** that **extend useful life**, **increase capacity**, **improve quality**, or **reduce operating costs**; at the same time, **derecognise** the carrying amount of the part replaced. :contentReference[oaicite:1]{index=1}
+- **Expense** **day-to-day servicing** (e.g., oil, filters, minor fixes) — these keep the asset running but **do not** increase capacity or extend useful life.  
+- **Capitalise** **significant replacements or upgrades** that **extend useful life**, **increase capacity**, **improve quality**, or **reduce operating costs**; at the same time, **derecognise** the carrying amount of the part replaced.
 
-This “component approach” is explicit in IFRS (and carried into **IFRS for SMEs Section 17**). :contentReference[oaicite:2]{index=2}
+This **component approach** is explicit in IFRS/IFRS for SMEs and prevents double-counting old parts.
 
 ## Decision checklist (fast)
-1) **What changed?** Routine upkeep → expense. New capability/longer life → consider capitalise. :contentReference[oaicite:3]{index=3}  
-2) **Is it a significant component?** If yes and replaced, **capitalise new part** and **remove old**. :contentReference[oaicite:4]{index=4}  
+1) **What changed?** Routine upkeep → expense. New capability/longer life → consider capitalise.  
+2) **Is it a significant component?** If yes and replaced, **capitalise new part** and **remove old**.  
 3) **Materiality**: if immaterial, expense for practicality (document your policy).  
-4) **VAT**: input VAT generally recoverable **only** if used for **taxable** supplies; apply **partial-exemption** if you have mixed supplies; note **special zero-rating** for certain capital equipment categories via GRA approvals. :contentReference[oaicite:5]{index=5}
+4) **VAT**: input VAT is generally recoverable **only** if used for **taxable** supplies; apply **partial-exemption** rules for mixed activities; note **special zero-rating** for certain capital equipment via GRA Policy 6 approvals.
 
 ## Worked examples (GYD)
 
 ### A. Routine servicing (expense)
-You service a delivery van (oil, filters, minor fixes) for **G$85,000 + VAT**.  
+Service a delivery van (oil, filters, minor fixes) for **G$85,000 + VAT**.  
 - **Dr Repairs & Maintenance** 85,000  
 - **Dr VAT Input** 11,900 *(14%)*  
 - **Cr Cash/Payables** 96,900  
-Explanation: no extension of life/capacity → **expense**. VAT input recoverable if the van supports **taxable** operations (subject to partial exemption if you also make exempt supplies). :contentReference[oaicite:6]{index=6}
+Explanation: no extension of life/capacity → **expense**. VAT input recoverable if the van supports **taxable** operations (subject to partial exemption if you also make exempt supplies).
 
 ### B. Major component replacement (capitalise + derecognise)
-You replace a **production machine motor** for **G$420,000 + VAT**; the old motor’s **carrying amount is G$60,000**. The new motor improves throughput and life.  
+Replace a **production machine motor** for **G$420,000 + VAT**; the old motor’s **carrying amount is G$60,000**. Throughput and useful life both increase.  
 - **Dr PPE – Machinery (new motor)** 420,000  
 - **Dr VAT Input** 58,800  
 - **Cr Cash/Payables** 478,800  
 - **Dr Loss on Disposal (old component)** 60,000  
 - **Cr PPE – Machinery (remove old motor)** 60,000  
-Explanation: replacement **extends useful life/increases capacity** → **capitalise**; derecognise the old component’s carrying amount. :contentReference[oaicite:7]{index=7}
+Explanation: replacement **extends useful life/increases capacity** → **capitalise**; derecognise the old component’s carrying amount.
 
 ### C. Upgrade that reduces operating cost (capitalise)
-You retrofit **LED plant lighting** for **G$300,000 + VAT**, cutting energy use materially; no old component is separately identifiable.  
+Retrofit **LED plant lighting** for **G$300,000 + VAT**, cutting energy use materially; no old component is separately identifiable.  
 - **Dr PPE – Improvements** 300,000  
 - **Dr VAT Input** 42,000  
 - **Cr Cash/Payables** 342,000  
-Explanation: the upgrade **improves future economic benefits** (lower costs) → **capitalise**; if no separable old component, no derecognition entry. :contentReference[oaicite:8]{index=8}
+Explanation: the upgrade **improves future economic benefits** (lower costs) → **capitalise**; if no separable old component, no derecognition entry.
 
 ## Policy notes (what to write down)
 - Define **capitalisation thresholds** (e.g., ≥ G$X) and examples per asset class.  
-- State that **routine servicing is expensed**; **replacements/upgrades** are capitalised and **replaced parts derecognised**. :contentReference[oaicite:9]{index=9}  
+- State that **routine servicing is expensed**; **replacements/upgrades** are capitalised and **replaced parts derecognised**.  
 - Require **evidence**: vendor docs describing the nature (service vs upgrade), asset IDs, and management approval.  
-- Review **useful life, residual value, and method annually**; adjust **prospectively** if estimates change (don’t restate past depreciation). :contentReference[oaicite:10]{index=10}
+- Review **useful life, residual value, and method annually**; **change prospectively** if estimates change (don’t restate past depreciation).
 
 ## VAT in Guyana (quick context)
-- Input VAT is allowed on purchases **used to make taxable supplies**; where activities are **mixed** (taxable + exempt), use **partial-exemption** to restrict recovery proportionally. :contentReference[oaicite:11]{index=11}  
-- **Capital equipment** used in specified sectors may be **zero-rated** (by approval) under GRA **Policy 6**—follow the CG-letter process. :contentReference[oaicite:12]{index=12}  
-- Keep **tax invoices** and link them to the asset/repair record for audits.
+- Input VAT is generally allowed on purchases **used to make taxable supplies**; where activities are **mixed** (taxable + exempt), use **partial-exemption** to restrict recovery.  
+- **Capital equipment** used in specified sectors may be **zero-rated** (by approval) under GRA **Policy 6** — follow the prescribed process.  
+- Keep **Tax Invoices** attached to the asset/repair record for audits.
 
 ## In heroBooks
 - Add the cost to the relevant **asset** (or **Repairs & Maintenance** for routine servicing).  
-- Use the **component** fields or notes to show replacements and **link the derecognition** entry (old part) for a clean audit trail.  
+- Use **component notes** to show replacements and **link derecognition** entries for audit trail.  
 - Depreciation will **recompute** from the new carrying amount over the revised remaining life.
 
----
+> **Figure:** see `/public/kb/illustrations/maintenance-vs-capital.svg` (1:1)
 
-**Illustration (1:1)**: `/public/kb/illustrations/maintenance-vs-capital.svg`  
-Alt text: "Decision tree: routine servicing → expense; replacement/upgrade extending life or capacity → capitalise and derecognise old component; VAT callouts for taxable vs mixed supplies."

--- a/public/kb/illustrations/maintenance-vs-capital.svg
+++ b/public/kb/illustrations/maintenance-vs-capital.svg
@@ -1,10 +1,53 @@
-<svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" width="120" height="120">
-  <rect x="10" y="10" width="40" height="30" rx="4" ry="4" fill="hsl(var(--primary))"/>
-  <text x="30" y="30" font-size="8" text-anchor="middle" fill="hsl(var(--foreground))">Service</text>
-  <rect x="70" y="10" width="40" height="30" rx="4" ry="4" fill="hsl(var(--secondary))"/>
-  <text x="90" y="30" font-size="8" text-anchor="middle" fill="hsl(var(--foreground))">Upgrade</text>
-  <line x1="30" y1="40" x2="30" y2="90" stroke="hsl(var(--border))" stroke-width="2"/>
-  <line x1="30" y1="90" x2="90" y2="90" stroke="hsl(var(--border))" stroke-width="2"/>
-  <circle cx="30" cy="90" r="4" fill="hsl(var(--accent))"/>
-  <circle cx="90" cy="90" r="4" fill="hsl(var(--accent))"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Decision tree showing expense vs capitalise with derecognition">
+  <style>
+    .bg { fill: var(--muted, #F5F7FA); }
+    .card { fill: var(--card, #FFFFFF); stroke: var(--border, #E5E7EB); stroke-width: 2; }
+    .title { fill: var(--foreground, #111827); font: 600 18px/1.3 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, 'Helvetica Neue', Arial; }
+    .label { fill: var(--foreground, #111827); font: 600 14px/1.3 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, 'Helvetica Neue', Arial; }
+    .text { fill: var(--muted-foreground, #4B5563); font: 13px/1.35 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, 'Helvetica Neue', Arial; }
+    .pill-exp { fill: var(--destructive, #EF4444); }
+    .pill-cap { fill: var(--primary, #2563EB); }
+    .arrow { stroke: var(--foreground, #111827); stroke-width: 2.5; fill: none; marker-end: url(#arrow); }
+    .tick { stroke: var(--primary, #2563EB); stroke-width: 2.5; fill: none; }
+    .cross { stroke: var(--destructive, #EF4444); stroke-width: 2.5; fill: none; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto-start-reverse">
+      <path d="M0,0 L8,4 L0,8 z" fill="var(--foreground, #111827)"/>
+    </marker>
+  </defs>
+  <rect class="bg" x="0" y="0" width="512" height="512" rx="24"/>
+
+  <!-- Root card -->
+  <rect class="card" x="56" y="36" width="400" height="88" rx="16"/>
+  <text class="title" x="256" y="72" text-anchor="middle">Maintenance vs Capital Improvements</text>
+  <text class="text" x="256" y="98" text-anchor="middle">Does the work extend life / increase capacity / reduce cost?</text>
+
+  <!-- Left branch: Expense -->
+  <path class="arrow" d="M256 124 C 180 160, 160 168, 120 188"/>
+  <rect class="card" x="48" y="188" width="176" height="120" rx="14"/>
+  <rect class="pill-exp" x="64" y="204" width="96" height="24" rx="12"/>
+  <text class="label" x="112" y="222" text-anchor="middle" fill="#fff">Expense</text>
+  <text class="text" x="64" y="242">• Routine servicing</text>
+  <text class="text" x="64" y="262">• No extra life/capacity</text>
+  <text class="text" x="64" y="282">• Debit R&amp;M (P/L)</text>
+  <path class="cross" d="M168 298 l12 12 m0 -12 l-12 12"/>
+
+  <!-- Right branch: Capitalise -->
+  <path class="arrow" d="M256 124 C 332 160, 352 168, 392 188"/>
+  <rect class="card" x="288" y="188" width="176" height="160" rx="14"/>
+  <rect class="pill-cap" x="304" y="204" width="112" height="24" rx="12"/>
+  <text class="label" x="360" y="222" text-anchor="middle" fill="#fff">Capitalise</text>
+  <text class="text" x="304" y="244">• Replacement/upgrade</text>
+  <text class="text" x="304" y="264">• Extend life / capacity</text>
+  <text class="text" x="304" y="284">• Derecognise old part</text>
+  <path class="tick" d="M300 300 l14 14 l22 -22"/>
+
+  <!-- VAT callout -->
+  <rect class="card" x="96" y="356" width="320" height="100" rx="14"/>
+  <text class="label" x="256" y="380" text-anchor="middle">VAT (Guyana) — quick notes</text>
+  <text class="text" x="112" y="404">• Input VAT only if used to make taxable supplies</text>
+  <text class="text" x="112" y="424">• Mixed activities → partial exemption</text>
+  <text class="text" x="112" y="444">• Some capital equipment can be zero-rated (GRA Policy 6)</text>
 </svg>


### PR DESCRIPTION
## Summary
- replace maintenance vs capital guide with decision checklist, GYD journal entries, and Guyana VAT notes
- add 1:1 SVG illustration showing expense vs capitalise with VAT callout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run kb:check` *(fails: Error: ❌ Placeholder text found in accounting-for-partnerships-in-cxc-poa.md)*


------
https://chatgpt.com/codex/tasks/task_e_68c0609f5fd08329a325efab4c2ce89a